### PR TITLE
Update README.md to show recursive clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Supported libraries
 ## Build & Use
 To build the project locally follow these steps:
 
-    $ git clone https://github.com/gircore/gir.core.git
+    $ git clone --recursive https://github.com/gircore/gir.core.git
     $ cd Build
     $ dotnet run -- release build
 


### PR DESCRIPTION
Found that the gir files are a module, so you need --recursive to fetch them.