### PR TITLE
Runtime Identifier

### DIFF
--- a/Libs/Directory.Build.props
+++ b/Libs/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RuntimeIdentifier>linux</RuntimeIdentifier>
     <LangVersion>8.0</LangVersion>
 
     <Nullable>enable</Nullable>


### PR DESCRIPTION
The runtime identifer is not needed at the moment (it is used for self contained deployments). It confuses omnisharp if build with windows (see https://github.com/gircore/gir.core/issues/38#issuecomment-674368380)