### PR TITLE
Fix for non-public constructors

### DIFF
--- a/Libs/GObject/Core/Classes/Object.cs
+++ b/Libs/GObject/Core/Classes/Object.cs
@@ -226,12 +226,17 @@ namespace GObject
                 throw new InvalidCastException();
 
             // Create using 'IntPtr' constructor
-            o = (T)Activator.CreateInstance(
-                trueType,
-                obj.Handle
+            var ctor = trueType.GetConstructor(
+                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+                null, new[] { typeof(IntPtr) }, null
             );
 
-            objects.Add(handle, (Object)(object)o);
+            o = (T)ctor.Invoke(new object[] { handle });
+
+            // TODO: We don't need the following line as
+            // we already add to the object dictionary in the
+            // constructor.
+            // objects.Add(handle, (Object)(object)o);
             return true;
         }
 


### PR DESCRIPTION
Fix for #52, allowing us to call protected and private `IntPtr` constructors (we cannot retrieve the Content Area of a Gtk.Dialog as Container's constructors are protected).

Also changes `o.Handle` to `handle`, as `o` is undefined in this call. I've switched `Activator.CreateInstance` to `GetConstructor` as it is more explicit - we could add error handling if the constructor is not found and notify the user?