### PR TITLE
Feature/generate documentation file

### DIFF
--- a/Build/Targets.cs
+++ b/Build/Targets.cs
@@ -14,6 +14,7 @@ namespace Build
         public const string Pack = "pack";
         public const string Samples = "samples";
         public const string Test = "test";
+        public const string Comments = "comments";
 
         #endregion
     }

--- a/Generator/Generator.cs
+++ b/Generator/Generator.cs
@@ -11,6 +11,12 @@ namespace Generator
 {
     public interface IGenerator
     {
+        #region Properties
+        
+        public bool GenerateComments { get; set; }
+        
+        #endregion
+        
         #region Methods
 
         void Generate();
@@ -36,6 +42,8 @@ namespace Generator
         #endregion
 
         #region Properties
+
+        public bool GenerateComments { get; set; }
 
         private GRepository Repository { get; }
         private Project Project { get; }
@@ -305,6 +313,11 @@ namespace Generator
                     return resolvedType.GetFieldString();
                 })
             );
+
+            scriptObject.Import("generate_comments",
+                new Func<bool>(() => GenerateComments)
+            );
+
             return scriptObject;
         }
 

--- a/Generator/Templates/GObject/class.sbntxt
+++ b/Generator/Templates/GObject/class.sbntxt
@@ -45,7 +45,7 @@ namespace {{ namespace }}
         {{~ if signals_have_event_args ~}}
 
         /// <summary>
-        /// Indexer to connect with an SignalHandler<{{name}}>
+        /// Indexer to connect with a SignalHandler
         /// </summary>
         public SignalHandler<{{ name }}> this[Signal<{{ name }}> signal]
         {

--- a/Generator/Templates/GObject/signal.sbntxt
+++ b/Generator/Templates/GObject/signal.sbntxt
@@ -34,7 +34,7 @@ end
 
 {{~ if $signal.needs_signal_args ~}}
 /// <summary>
-/// Indexer to connect {{ $signal_descriptor_name }} with an SignalHandler<{{$signal_generic_args}}>
+/// Indexer to connect {{ $signal_descriptor_name }} with a SignalHandler
 /// </summary>
 public SignalHandler<{{ $signal_generic_args }}> this[Signal<{{ $signal_generic_args }}> signal]
 {

--- a/Generator/Templates/Shared/helper.sbntxt
+++ b/Generator/Templates/Shared/helper.sbntxt
@@ -23,7 +23,7 @@ end
 
 func get_summary(obj, prefix = "")
     $ret = ""
-    if obj.doc?.text
+    if generate_comments && obj.doc?.text
         $ret = $ret + prefix + "/// <summary>\r\n"
         $ret = $ret + (obj.doc.text | comment_line_by_line_with_prefix prefix)
         $ret = $ret + prefix + "/// </summary>\r\n"
@@ -37,7 +37,7 @@ func get_obsolete_attribute(obj)
     
     if obj?.deprecated
         $text = ""
-        if obj.doc_deprecated
+        if generate_comments && obj.doc_deprecated
             $text = obj.doc_deprecated.text | make_single_line | escape_quotes
         end
         $ret = '[Obsolete("' + $text + '")]\r\n'

--- a/Libs/Directory.Build.props
+++ b/Libs/Directory.Build.props
@@ -12,4 +12,9 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="$(Configuration.ToLower().Equals('release'))">
+    <nowarn>1591</nowarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
 </Project>

--- a/Libs/GObject/Classes/Object.Properties.cs
+++ b/Libs/GObject/Classes/Object.Properties.cs
@@ -52,7 +52,7 @@ namespace GObject
         /// </summary>
         /// <param name="name">The property name.</param>
         /// <returns>
-        /// The native value of the property, wrapped is a <see cref="Sys.Value"/>.
+        /// The native value of the property, wrapped is a <see cref="Value"/>.
         /// </returns>
         private Value GetGProperty(string? name)
         {

--- a/Libs/Gst/Classes/Parse.cs
+++ b/Libs/Gst/Classes/Parse.cs
@@ -9,7 +9,7 @@ namespace Gst
         /// </summary>
         /// <param name="pipelineDescription">Description of the pipeline</param>
         /// <returns>A new element</returns>
-        /// <exception cref="GException">Throws an exception in case of an error</exception>
+        /// <exception cref="GLib.GException">Throws an exception in case of an error</exception>
         public static Element Launch(string pipelineDescription)
         {
             //TODO: As this method wrapps a global function it should probably be part of the toolkit layer.


### PR DESCRIPTION
- This generates the xml documentation file in release mode.
- As warnings are errors it supresses warning CS1591 which warns about missing xml comments for public members
- The comments from the gir files are not generated into the wrapper code if in release mode. In this way we can create a public documentation based on our own comments.
- In debug mode the the gir comments are still generated into the wrapper code.