### PR TITLE
Generate the correct library names for macOS.

### DIFF
--- a/Generator/Gir/GNamespace.cs
+++ b/Generator/Gir/GNamespace.cs
@@ -76,6 +76,8 @@ namespace Gir
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return GetWindowsDllImport(name, version);
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return GetOSXDllImport(name, version);
             else
                 return GetLinuxDllImport(name, version);
         }
@@ -87,6 +89,15 @@ namespace Gir
                 versionExtension = "-" + version;
 
             return name + versionExtension + ".dll";
+        }
+
+        private string GetOSXDllImport(string name, string version)
+        {
+            var versionExtension = "";
+            if (!string.IsNullOrEmpty(version))
+                versionExtension = "." + version;
+
+            return name + versionExtension + ".dylib";
         }
 
         private string GetLinuxDllImport(string name, string version)


### PR DESCRIPTION
The libraries are named e.g. `libgtk-3.0.dylib` on macOS.

I tested with the GTK libraries installed via homebrew, and this fixes the runtime errors I hit while running the sample GTK application.