### PR TITLE
Feature/fix references

### DIFF
--- a/Generator/Templates/GObject/class.sbntxt
+++ b/Generator/Templates/GObject/class.sbntxt
@@ -61,7 +61,7 @@ namespace {{ namespace }}
         {{~ if has_parent ~}} 
         #region Constructors
 
-        protected internal {{ name }}(IntPtr ptr) : base(ptr) {}
+        protected internal {{ name }}(IntPtr ptr, bool ownedRef) : base(ptr, ownedRef) {}
         protected internal {{ name }}(params ConstructParameter[] properties) : base(properties) {}
 
         #endregion

--- a/Generator/Templates/Shared/helper.sbntxt
+++ b/Generator/Templates/Shared/helper.sbntxt
@@ -28,13 +28,8 @@ func verify(value, error)
 end
 
 func get_return(obj, prefix = "")
-    $ret = "";
-    
-    if obj.return_value?.transfer_ownership
-        $ret = $ret + prefix + "/// <returns>Transfer ownership: " + obj.return_value.transfer_ownership + "</returns>\r\n"
-    end
-    
-    ret $ret;
+    $data = obj.return_value | get_metadata 
+    ret prefix + "/// <returns>" + ($data | array.join "; ") + "</returns>\r\n"
 end
 
 func get_params(obj, prefix = "")
@@ -58,16 +53,8 @@ func get_params(obj, prefix = "")
 end
 
 func get_param_text(parameter)
-    $ret = ""
-    $ret = $ret + "/// <param name=\"" + parameter.name +"\">"
-    
-    if parameter.transfer_ownership
-        $ret = $ret + "Transfer ownership: " + parameter.transfer_ownership
-    end
-    
-    $ret = $ret + "</param>\r\n"
-    
-    ret $ret;
+    $data = parameter | get_metadata 
+    ret "/// <param name=\"" + parameter.name +"\">" + ($data | array.join "; ") + "</param>\r\n"
 end
 
 func get_summary(obj, prefix = "")
@@ -93,6 +80,20 @@ func get_obsolete_attribute(obj)
     end
     
     ret $ret
+end
+
+func get_metadata(obj)
+    $data = []
+    
+    if obj?.transfer_ownership
+        $data = $data | array.add ("Transfer ownership: " + obj.transfer_ownership)
+    end
+    
+    if obj?.nullable
+        $data = $data | array.add ("Nullable: " + obj.nullable)
+    end
+    
+    ret $data
 end
 
 func get_parameters(method)

--- a/Libs/GObject/Classes/Object.cs
+++ b/Libs/GObject/Classes/Object.cs
@@ -45,8 +45,8 @@ namespace GObject
         /// Constructs a new object
         /// </summary>
         /// <param name="properties"></param>
-        /// <remarks>This constructor is protected to be sure that there is no caller (enduser) keeping a reference tothe
-        /// construct parameters as the contained values are freed at the end of this constructor.
+        /// <remarks>This constructor is protected to be sure that there is no caller (enduser) keeping a reference to
+        /// the construct parameters as the contained values are freed at the end of this constructor.
         /// If certain constructors are needed they need to be implemented with concrete constructor arguments in
         /// a higher layer.</remarks>
         protected Object(params ConstructParameter[] properties)

--- a/Libs/GObject/Classes/Object.cs
+++ b/Libs/GObject/Classes/Object.cs
@@ -45,7 +45,11 @@ namespace GObject
         /// Constructs a new object
         /// </summary>
         /// <param name="properties"></param>
-        public Object(params ConstructParameter[] properties)
+        /// <remarks>This constructor is protected to be sure that there is no caller (enduser) keeping a reference tothe
+        /// construct parameters as the contained values are freed at the end of this constructor.
+        /// If certain constructors are needed they need to be implemented with concrete constructor arguments in
+        /// a higher layer.</remarks>
+        protected Object(params ConstructParameter[] properties)
         {
             // This will automatically register our
             // type in the type dictionary. If the type is

--- a/Libs/GObject/Classes/Object.cs
+++ b/Libs/GObject/Classes/Object.cs
@@ -77,14 +77,15 @@ namespace GObject
 
                 IntPtr zero = IntPtr.Zero;
 
-                // Create with properties: The new object is owned by us even in case of an object
-                // which inherits GInitially unowned.
                 handle = Native.new_with_properties(
                     typeId.Value,
                     (uint) properties.Length,
                     ref (properties.Length > 0 ? ref names[0] : ref zero),
                     values
                 );
+
+                if (Native.is_floating(handle))
+                    Native.ref_sink(handle); //Make sure handle is owned by us
             }
             finally
             {

--- a/Libs/GObject/Classes/Object.cs
+++ b/Libs/GObject/Classes/Object.cs
@@ -74,15 +74,15 @@ namespace GObject
                     names[i] = Marshal.StringToHGlobalAnsi(prop.Name);
                     values[i] = prop.Value;
                 }
-               
-                IntPtr ptrFirstName = properties.Length > 0 ? names[0] : IntPtr.Zero;
+
+                IntPtr zero = IntPtr.Zero;
 
                 // Create with properties: The new object is owned by us even in case of an object
                 // which inherits GInitially unowned.
                 handle = Native.new_with_properties(
                     typeId.Value,
                     (uint) properties.Length,
-                    ref ptrFirstName,
+                    ref (properties.Length > 0 ? ref names[0] : ref zero),
                     values
                 );
             }
@@ -91,7 +91,7 @@ namespace GObject
                 foreach (IntPtr ptr in names)
                     Marshal.FreeHGlobal(ptr);
 
-                foreach(Value value in values)
+                foreach (Value value in values)
                     value.Dispose();   
             }
 

--- a/Libs/GObject/Structs/Value.cs
+++ b/Libs/GObject/Structs/Value.cs
@@ -100,7 +100,7 @@ namespace GObject
         public IntPtr GetBoxed() => Native.get_boxed(ref this);
 
         public Object? GetObject()
-            => Object.TryWrapHandle(Native.get_object(ref this), out Object? obj) ? obj : null;
+            => Object.TryWrapHandle(Native.get_object(ref this), false, out Object? obj) ? obj : null;
 
         public bool GetBool() => Native.get_boolean(ref this);
         public uint GetUint() => Native.get_uint(ref this);

--- a/Libs/Gdk3/Classes/Screen.cs
+++ b/Libs/Gdk3/Classes/Screen.cs
@@ -1,12 +1,8 @@
-using System;
-using GObject;
-using System.Runtime.InteropServices;
-
 namespace Gdk
 {   
     public partial class Screen
     {
-        public static Gdk.Screen GetDefault()
-            => WrapHandle<Gdk.Screen>(Native.get_default());
+        public static Screen? GetDefault()
+            => WrapNullableHandle<Screen>(Native.get_default(), false);
     }
 }

--- a/Libs/Gio/Classes/DBusConnection.cs
+++ b/Libs/Gio/Classes/DBusConnection.cs
@@ -13,10 +13,7 @@ namespace Gio
             IntPtr handle = Global.Native.bus_get_sync(busType, IntPtr.Zero, out IntPtr error);
             Error.ThrowOnError(error);
 
-            if (GetObject(handle, out DBusConnection obj))
-                return obj;
-
-            return new DBusConnection(handle);
+            return WrapHandle<DBusConnection>(handle, true);
         }
         
         #endregion

--- a/Libs/Gio/Classes/DBusConnection.cs
+++ b/Libs/Gio/Classes/DBusConnection.cs
@@ -25,6 +25,7 @@ namespace Gio
         {
             var tcs = new TaskCompletionSource<Variant>();
 
+            //TODO: This could be garbage collected and the callback would not work anymore
             void Callback(IntPtr sourceObject, IntPtr res, IntPtr userData)
             {
                 IntPtr ret = Native.call_finish(sourceObject, res, out IntPtr error);

--- a/Libs/Gst/Classes/Element.cs
+++ b/Libs/Gst/Classes/Element.cs
@@ -50,21 +50,11 @@ namespace Gst
 
             Error.ThrowOnError(errPtr);
 
-            return TryWrapHandle(result, out Element? element) ? element : null;
+            return WrapNullableHandle<Element>(result, false);
         }
         
-        public Bus GetBus()
-        {
-            IntPtr ret = Native.get_bus(Handle);
-            
-            if (GetObject(ret, out Bus obj))
-                return obj;
-
-            if(ret == IntPtr.Zero)
-                throw new Exception("Could not convert pointer to bus");
-            
-            return new Bus(ret);
-        }
+        public Bus? GetBus()
+            => WrapNullableHandle<Bus>(Native.get_bus(Handle), true);
 
         public bool AddPad(Pad pad) => Native.add_pad(Handle, pad.Handle);
 
@@ -99,8 +89,8 @@ namespace Gst
             return Native.query_duration(Handle, format, out duration);
         }
 
-        public Pad GetStaticPad(string name)
-            => WrapHandle<Pad>(Native.get_static_pad(Handle, name));
+        public Pad? GetStaticPad(string name)
+            => WrapNullableHandle<Pad>(Native.get_static_pad(Handle, name), true);
         
         public static void Unlink(Element src, Element dest)
             => Native.unlink(src.Handle, dest.Handle);
@@ -135,7 +125,7 @@ namespace Gst
         }
 
         public Pad? GetRequestPad(string name)
-            => TryWrapHandle(Native.get_request_pad(Handle, name), out Pad? pad) ? pad : null;
+            => WrapNullableHandle<Pad>(Native.get_request_pad(Handle, name), true);
 
         public bool SyncStateWithParent()
             => Native.sync_state_with_parent(Handle);

--- a/Libs/Gst/Classes/Element.cs
+++ b/Libs/Gst/Classes/Element.cs
@@ -44,13 +44,13 @@ namespace Gst
 
         #endregion
 
-        public static Element? MakeFromUri(URIType type, string uri, string elementName)
+        public static Element MakeFromUri(URIType type, string uri, string elementName)
         {
             IntPtr result = Native.make_from_uri(type, uri, elementName, out IntPtr errPtr);
 
             Error.ThrowOnError(errPtr);
 
-            return WrapNullableHandle<Element>(result, false);
+            return WrapHandle<Element>(result, false);
         }
         
         public Bus? GetBus()

--- a/Libs/Gst/Classes/ElementFactory.cs
+++ b/Libs/Gst/Classes/ElementFactory.cs
@@ -3,11 +3,6 @@
     public partial class ElementFactory
     {
         public static Element? Make(string factoryName, string name)
-        {
-            if (TryWrapHandle(Native.make(factoryName, name), out Element? element))
-                return element;
-
-            return null;
-        }
+            => WrapNullableHandle<Element>(Native.make(factoryName, name), false);
     }
 }

--- a/Libs/Gst/Classes/GhostPad.cs
+++ b/Libs/Gst/Classes/GhostPad.cs
@@ -12,7 +12,7 @@ namespace Gst
         // which *must* be run. Therefore our existing constructor design is
         // inadequate.
         public static GhostPad New(string name, Pad target)
-            => WrapHandle<GhostPad>(Native.@new(name, target.Handle));
+            => WrapHandle<GhostPad>(Native.@new(name, target.Handle), false);
 
         public bool SetTarget(Pad newTarget)
             => Native.set_target(Handle, newTarget.Handle);

--- a/Libs/Gst/Classes/GhostPad.cs
+++ b/Libs/Gst/Classes/GhostPad.cs
@@ -11,8 +11,8 @@ namespace Gst
         // not simply a wrapper for g_object_new and has essential logic inside
         // which *must* be run. Therefore our existing constructor design is
         // inadequate.
-        public static GhostPad New(string name, Pad target)
-            => WrapHandle<GhostPad>(Native.@new(name, target.Handle), false);
+        public static GhostPad? New(string name, Pad target)
+            => WrapNullableHandle<GhostPad>(Native.@new(name, target.Handle), false);
 
         public bool SetTarget(Pad newTarget)
             => Native.set_target(Handle, newTarget.Handle);

--- a/Libs/Gst/Classes/Pad.cs
+++ b/Libs/Gst/Classes/Pad.cs
@@ -26,10 +26,10 @@ namespace Gst
 
         public Caps? QueryCaps() => QueryCaps(null);
 
-        public Pad? GetPeer() => TryWrapHandle<Pad>(Native.get_peer(Handle), out Pad? pad) ? pad : null;
+        public Pad? GetPeer() => WrapNullableHandle<Pad>(Native.get_peer(Handle), true);
 
         public Element? GetParentElement() =>
-            TryWrapHandle<Element>(Native.get_parent_element(Handle), out Element? element) ? element : null;
+            WrapNullableHandle<Element>(Native.get_parent_element(Handle), true);
 
         public ulong AddProbe(PadProbeType mask, PadProbeCallback callback, DestroyNotify? notify = null)
         {

--- a/Libs/Gst/Classes/Parse.cs
+++ b/Libs/Gst/Classes/Parse.cs
@@ -16,7 +16,7 @@ namespace Gst
 
             GLib.Error.ThrowOnError(error);
 
-            return GObject.Object.WrapHandle<Element>(ret);
+            return GObject.Object.WrapHandle<Element>(ret, false);
         }
 
         public static Element BinFromDescription(string binDescription, bool ghostUnlinkedPads)
@@ -25,7 +25,7 @@ namespace Gst
             
             GLib.Error.ThrowOnError(error);
             
-            return GObject.Object.WrapHandle<Element>(ret);
+            return GObject.Object.WrapHandle<Element>(ret, false);
         }
     }
 }

--- a/Libs/Gst/Structs/Message.cs
+++ b/Libs/Gst/Structs/Message.cs
@@ -17,6 +17,7 @@ namespace Gst
     {
         public MessageType Type => type;
         
+        //TODO: Clarify if this is needed, see: https://github.com/gircore/gir.core/pull/184#discussion_r554907963
         public Gst.Object Src
         {
             get => GObject.Object.WrapHandle<Gst.Object>(src, false);

--- a/Libs/Gst/Structs/Message.cs
+++ b/Libs/Gst/Structs/Message.cs
@@ -19,7 +19,7 @@ namespace Gst
         
         public Gst.Object Src
         {
-            get => GObject.Object.WrapHandle<Gst.Object>(src);
+            get => GObject.Object.WrapHandle<Gst.Object>(src, false);
             set => src = value.Handle;
         }
 

--- a/Libs/Gtk3/Classes/AboutDialog.cs
+++ b/Libs/Gtk3/Classes/AboutDialog.cs
@@ -432,7 +432,7 @@ namespace Gtk
         public void SetTranslatorCredits(string translatorCredits) =>
             Native.set_translator_credits(Handle, translatorCredits);
 
-        public GdkPixbuf.Pixbuf GetLogo() => WrapHandle<GdkPixbuf.Pixbuf>(Native.get_logo(Handle));
+        public GdkPixbuf.Pixbuf GetLogo() => WrapHandle<GdkPixbuf.Pixbuf>(Native.get_logo(Handle), false);
 
         public void SetLogo(GdkPixbuf.Pixbuf? logo) =>
             Native.set_logo(Handle, logo is null ? IntPtr.Zero : logo.Handle);

--- a/Libs/Gtk3/Classes/Builder.cs
+++ b/Libs/Gtk3/Classes/Builder.cs
@@ -96,7 +96,7 @@ namespace Gtk
                 if(ptr == IntPtr.Zero)
                     throw new Exception($"{field.ReflectedType?.FullName} Field {field.Name}: Could not find an element in the template with the name {element}");
 
-                var newElement = constructor.Invoke(new object[] {ptr});
+                var newElement = constructor.Invoke(new object[] { ptr, false});
                 field.SetValue(obj, newElement);
             }
         }
@@ -105,10 +105,13 @@ namespace Gtk
         {
             var parameters = constructorInfo.GetParameters();
 
-            if(parameters.Length != 1)
+            if (parameters.Length != 2)
                 return false;
 
-            if(parameters.First().ParameterType != typeof(IntPtr))
+            if (parameters[0].ParameterType != typeof(IntPtr))
+                return false;
+            
+            if(parameters[1].ParameterType != typeof(bool))
                 return false;
 
             return true;

--- a/Libs/Gtk3/Classes/Builder.cs
+++ b/Libs/Gtk3/Classes/Builder.cs
@@ -10,7 +10,7 @@ namespace Gtk
     public partial class Builder
     {
         #region Constructors
-        public Builder(string template) : this(Native.@new())
+        public Builder(string template)
         {
             var templateContent = GetTemplate(Assembly.GetCallingAssembly(), template);
             var length = (ulong) Encoding.UTF8.GetByteCount(templateContent);

--- a/Libs/Gtk3/Classes/Dialog.cs
+++ b/Libs/Gtk3/Classes/Dialog.cs
@@ -10,12 +10,12 @@ namespace Gtk
         public Dialog() { }
         
         public Widget GetContentArea()
-            => WrapHandle<Widget>(Native.get_content_area(Handle));
+            => WrapHandle<Box>(Native.get_content_area(Handle), false);
 
         // TODO: Allow for arbitrary response IDs, not just
         // the ones in Gtk.ResponseType
         public Widget AddButton(string buttonText, ResponseType responseId)
-            => WrapHandle<Widget>(Native.add_button(Handle, buttonText, responseId));
+            => WrapHandle<Widget>(Native.add_button(Handle, buttonText, responseId), false);
 
         public int Run() => Native.run(Handle);
     }

--- a/Libs/Gtk3/Classes/FileChooserButton.cs
+++ b/Libs/Gtk3/Classes/FileChooserButton.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using GObject;
+﻿using GObject;
 
 namespace Gtk
 {
@@ -110,6 +105,6 @@ namespace Gtk
             ConstructParameter.With(DialogProperty, dialog)) {}
 
         public static FileChooserButton New(string title, FileChooserAction action)
-            => new FileChooserButton(Native.@new(title, action));
+            => new FileChooserButton(Native.@new(title, action), false);
     }
 }

--- a/Libs/Gtk3/Classes/Widget.CompositeWidget.cs
+++ b/Libs/Gtk3/Classes/Widget.CompositeWidget.cs
@@ -29,7 +29,7 @@ namespace Gtk
             var systemType = GetType();
             var gtype = TypeDictionary.Get(systemType);
             IntPtr ptr = Native.get_template_child(Handle, gtype.Value, name);
-            field = WrapHandle<T>(ptr);
+            field = WrapHandle<T>(ptr, false);
         }
 
         protected static void BindTemplateChild(Type gtype, string name)
@@ -52,7 +52,7 @@ namespace Gtk
         private static void OnConnectEvent(IntPtr builder, IntPtr @object, string signal_name, string handler_name,
             IntPtr connect_object, ConnectFlags flags, IntPtr user_data)
         {
-            if(!TryWrapHandle<Widget>(@object, out var eventSender))
+            if(!TryWrapHandle<Widget>(@object, false, out var eventSender))
                 return;
 
             if (!TryGetEvent(eventSender.GetType(), signal_name, out EventInfo? @event))
@@ -61,7 +61,7 @@ namespace Gtk
             if (@event.EventHandlerType is null)
                 return;
             
-            if(!TryWrapHandle<Widget>(connect_object, out var compositeWidget))
+            if(!TryWrapHandle<Widget>(connect_object, false, out var compositeWidget))
                 return;
 
             if (!TryGetMethod(compositeWidget.GetType(), handler_name, out MethodInfo? compositeWidgetEventHandler))

--- a/Libs/Gtk3/Classes/Widget.cs
+++ b/Libs/Gtk3/Classes/Widget.cs
@@ -90,8 +90,8 @@ namespace Gtk
 
         public void ShowAll() => Native.show_all(Handle);
         public void Show() => Native.show(Handle);
-        public StyleContext GetStyleContext() => WrapHandle<StyleContext>(Native.get_style_context(Handle));
+        public StyleContext GetStyleContext() => WrapHandle<StyleContext>(Native.get_style_context(Handle), false);
 
-        public Gdk.Screen GetScreen() => WrapHandle<Gdk.Screen>(Native.get_screen(Handle));
+        public Gdk.Screen GetScreen() => WrapHandle<Gdk.Screen>(Native.get_screen(Handle), false);
     }
 }

--- a/Libs/Gtk3/Classes/Window.cs
+++ b/Libs/Gtk3/Classes/Window.cs
@@ -911,7 +911,7 @@ namespace Gtk
             Native.get_hide_titlebar_when_maximized(Handle);
 
         public GdkPixbuf.Pixbuf? GetIcon() =>
-            WrapNullableHandle<GdkPixbuf.Pixbuf>(Native.get_icon(Handle),false);
+            WrapNullableHandle<GdkPixbuf.Pixbuf>(Native.get_icon(Handle), false);
 
         public GLib.List GetIconList()
         {

--- a/Libs/Gtk3/Classes/Window.cs
+++ b/Libs/Gtk3/Classes/Window.cs
@@ -950,15 +950,11 @@ namespace Gtk
         public string? GetTitle() =>
             Marshal.PtrToStringAnsi(Native.get_title(Handle));
 
-        public Window? GetTransientFor()
-        {
-            return WrapNullableHandle<Window>(Native.get_transient_for(Handle), false);
-        }
+        public Window? GetTransientFor() =>
+            WrapNullableHandle<Window>(Native.get_transient_for(Handle), false);
 
-        public Widget? GetAttachedTo()
-        {
-            return WrapNullableHandle<Widget>(Native.get_attached_to(Handle), false);
-        }
+        public Widget? GetAttachedTo() =>
+            WrapNullableHandle<Widget>(Native.get_attached_to(Handle), false);
 
         public Gdk.WindowTypeHint GetTypeHint() =>
             Native.get_type_hint(Handle);

--- a/Libs/Gtk3/Classes/Window.cs
+++ b/Libs/Gtk3/Classes/Window.cs
@@ -791,11 +791,8 @@ namespace Gtk
         public Widget? GetFocus() =>
             GetFocus<Widget>();
 
-        public T? GetFocus<T>() where T : Widget
-        {
-            IntPtr focusPtr = Native.get_focus(Handle);
-            return focusPtr == IntPtr.Zero ? null : WrapHandle<T>(focusPtr);
-        }
+        public T? GetFocus<T>() where T : Widget =>
+            WrapNullableHandle<T>(Native.get_focus(Handle), false);
 
         public void SetFocus(Widget? focus) =>
             Native.set_focus(Handle, focus is null ? IntPtr.Zero : focus.Handle);
@@ -1092,11 +1089,8 @@ namespace Gtk
             return result;
         }
 
-        public Application? GetApplication()
-        {
-            IntPtr appPtr = Native.get_application(Handle);
-            return appPtr == IntPtr.Zero ? null : WrapHandle<Application>(appPtr);
-        }
+        public Application? GetApplication() =>
+            WrapNullableHandle<Application>(Native.get_application(Handle), false);
 
         public void SetApplication(Application? application) =>
             Native.set_application(Handle, application is null ? IntPtr.Zero : application.Handle);
@@ -1107,11 +1101,8 @@ namespace Gtk
         public void SetTitlebar(Widget? titlebar) =>
             Native.set_titlebar(Handle, titlebar is null ? IntPtr.Zero : titlebar.Handle);
 
-        public Widget? GetTitlebar()
-        {
-            IntPtr ptr = Native.get_titlebar(Handle);
-            return ptr == IntPtr.Zero ? null : WrapHandle<Widget>(ptr);
-        }
+        public Widget? GetTitlebar() =>
+            WrapNullableHandle<Widget>(Native.get_titlebar(Handle), false);
 
         public static void SetInteractiveDebugging(bool enable) =>
             Native.set_interactive_debugging(enable);

--- a/Libs/Gtk3/Classes/Window.cs
+++ b/Libs/Gtk3/Classes/Window.cs
@@ -757,7 +757,7 @@ namespace Gtk
             Native.set_screen(Handle, screen.Handle);
 
         public new Gdk.Screen GetScreen() =>
-            WrapHandle<Gdk.Screen>(Native.get_screen(Handle));
+            WrapHandle<Gdk.Screen>(Native.get_screen(Handle), false);
 
         public GLib.List ListToplevels()
         {
@@ -913,8 +913,8 @@ namespace Gtk
         public bool GetHideTitlebarWhenMaximized() =>
             Native.get_hide_titlebar_when_maximized(Handle);
 
-        public GdkPixbuf.Pixbuf GetIcon() =>
-            WrapHandle<GdkPixbuf.Pixbuf>(Native.get_icon(Handle));
+        public GdkPixbuf.Pixbuf? GetIcon() =>
+            WrapNullableHandle<GdkPixbuf.Pixbuf>(Native.get_icon(Handle),false);
 
         public GLib.List GetIconList()
         {
@@ -955,14 +955,12 @@ namespace Gtk
 
         public Window? GetTransientFor()
         {
-            IntPtr windowPtr = Native.get_transient_for(Handle);
-            return windowPtr == IntPtr.Zero ? null : WrapHandle<Window>(windowPtr);
+            return WrapNullableHandle<Window>(Native.get_transient_for(Handle), false);
         }
 
         public Widget? GetAttachedTo()
         {
-            IntPtr widgetPtr = Native.get_attached_to(Handle);
-            return widgetPtr == IntPtr.Zero ? null : WrapHandle<Widget>(widgetPtr);
+            return WrapNullableHandle<Widget>(Native.get_attached_to(Handle), false);
         }
 
         public Gdk.WindowTypeHint GetTypeHint() =>

--- a/Samples/Gtk3/GtkMinimal/DemoWindow.cs
+++ b/Samples/Gtk3/GtkMinimal/DemoWindow.cs
@@ -14,7 +14,7 @@ namespace GtkDemo
         private Notebook notebook;
 
         public DemoWindow(Application application) : this(application, new Builder("demo_window.glade")) { }
-        private DemoWindow(Application application, Builder builder) : base(builder.GetObject("root"))
+        private DemoWindow(Application application, Builder builder) : base(builder.GetObject("root"), false)
         {
             Application = application;
             builder.Connect(this);


### PR DESCRIPTION
Fixes #78 

This adds the concept of *owned refs* to the API. Every wrapped IntPtr must be defined as owned or not. If a pointer is owned it means that the ownership of this part of the memory is transferred to us. We do not have to increase the reference count as we just grab the responsibility. In case this owned reference is floating, we are `Debug.Assert`ing the program as this scenario is not possible.

In case the ownership is not transferred to us this means some other other code owns the reference. In this case we ref the object to make sure that we want to own this reference, too. Meaning as long as our C# object exists the memory can not be freed via an `unref`.

As our objects get notified in case of finalization of a gobject even if we still own a reference we remove the object from our global object array and mark ourself as disposed. 

In case of an object create directly by us via `new ...` we don't need to increase the reference count as `Object.new_with_properties` transfers the ownership to us even in case of an initially unowned object.

Changes
- Supply the `ownedRef` parameter if wrapping a pointer
- The new code fixes a bug which first set the handle to `IntPtr.Zero` and afterwards tried to remove the object via the nulled handle.
- The code for the object constructor with parameters is simplified and removes the double branches
- The code for the object constructor with parameters frees the `Values` passed into it. If we free those, we need to be sure that the caller is not keeping a reference to the `ConstructParameter`s. For this reason I marked the constructor as protected. In this way the derived classes can use ConstructProperties to provde constructors with concrete arguments to the enduser.
- Added nullable information to the xml documentation.
- Added support for wrapping of nullable pointers and adopted our current methods to use the new method if applicable

@firox263 : I changed some GStreamer method signatures which were wrong according to documentation. I assume that this should not break your work or if so at least be "the right" api. Could you verify?