### PR TITLE
Fix delegate return values

### DIFF
--- a/Generator/Factories/ScriptObjectFactory.cs
+++ b/Generator/Factories/ScriptObjectFactory.cs
@@ -42,6 +42,7 @@ namespace Generator.Factories
             scriptObject.Import("signals_have_args", new Func<IEnumerable<Signal>, bool>(TemplateWriter.SignalsHaveArgs));
             scriptObject.Import("write_callback_marshaller", new Func<IEnumerable<Argument>, ReturnValue, string>((a, r) => TemplateWriter.WriteCallbackMarshaller(a, r, currentNamespace)));
             scriptObject.Import("write_class_struct_fields", new Func<IEnumerable<Field>, string, string>((f,s) => f.WriteClassStructFields(s, currentNamespace)));
+            scriptObject.Import("return_value_is_void", new Func<ReturnValue, bool>(r => r.IsVoid()));
             
             return scriptObject;
         }

--- a/Generator/TemplateWriter.cs
+++ b/Generator/TemplateWriter.cs
@@ -51,7 +51,7 @@ namespace Generator
             
             var funcCall = returnValue.IsVoid()
                 ? $"managedCallback({funcArgs});" 
-                : $"var result = managedCallback({funcArgs});\r\n\r\n return result;";
+                : $"var managed_callback_result = managedCallback({funcArgs});";
 
             builder.Append(funcCall);
 

--- a/Generator/Templates/delegate.sbntxt
+++ b/Generator/Templates/delegate.sbntxt
@@ -29,6 +29,10 @@ namespace {{ namespace.name }}
         private {{ return_value | write_managed_return_value }} NativeCallbackMarshaller({{ arguments | write_native_arguments}})
         {
             {{ include 'delegate.marshaller.sbntxt' }}
+            
+            {{~ if return_value | return_value_is_void != true ~}}
+            return managed_callback_result;
+            {{~ end ~}}
         }
     }
     
@@ -56,6 +60,10 @@ namespace {{ namespace.name }}
             
             // Async callbacks are only ever called once
             gch.Free();
+            
+            {{~ if return_value | return_value_is_void != true ~}}
+            return managed_callback_result;
+            {{~ end ~}}
         }
     }
 
@@ -85,6 +93,10 @@ namespace {{ namespace.name }}
         private {{ return_value | write_managed_return_value }} NativeCallbackMarshaller({{ arguments | write_native_arguments}})
         {
             {{ include 'delegate.marshaller.sbntxt' }}
+            
+            {{~ if return_value | return_value_is_void != true ~}}
+            return managed_callback_result;
+            {{~ end ~}}
         }
 
         private void DestroyCallback(IntPtr? userData)


### PR DESCRIPTION
Only generates a return statement for a delegate if it has a non-void return value. Also changes the name of the returned variable to avoid name conflicts.