### PR TITLE
Use nuint as gsize datatype

### DIFF
--- a/Libs/GLib-2.0/Records/Bytes.cs
+++ b/Libs/GLib-2.0/Records/Bytes.cs
@@ -30,7 +30,7 @@ namespace GLib
 
         public static Bytes From(byte[] data)
         {
-            var obj = new Bytes(Native.Bytes.Methods.New(data, (ulong) data.Length));
+            var obj = new Bytes(Native.Bytes.Methods.New(data, (nuint) data.Length));
             return obj;
         }
 

--- a/Libs/GLib-2.0/Records/Variant.cs
+++ b/Libs/GLib-2.0/Records/Variant.cs
@@ -66,13 +66,13 @@ namespace GLib
         {
             _children = children;
 
-            var count = children.Length;
+            var count = (nuint) children.Length;
             var ptrs = new IntPtr[count];
 
-            for (var i = 0; i < count; i++)
+            for (nuint i = 0; i < count; i++)
                 ptrs[i] = children[i].Handle.DangerousGetHandle();
 
-            handle = Native.Variant.Methods.NewTuple(ptrs, (ulong) count);
+            handle = Native.Variant.Methods.NewTuple(ptrs, count);
             Native.Variant.Methods.RefSink(handle);
         }
 

--- a/Libs/GObject-2.0/Classes/Functions.cs
+++ b/Libs/GObject-2.0/Classes/Functions.cs
@@ -4,13 +4,13 @@ namespace GObject
 {
     public partial class Functions
     {
-        internal static bool TypeIsA(ulong type, Types isAType)
-            => Native.Functions.TypeIsA(type, (ulong) isAType);
+        internal static bool TypeIsA(nuint type, nuint isAType)
+            => Native.Functions.TypeIsA(type, isAType);
 
         // "g_strv_get_type" method is defined in GLib gir file but is
         // historically part of the GObject shared library. This is
         // why it is defined manually here.
         [DllImport("GObject", EntryPoint = "g_strv_get_type")]
-        internal static extern ulong StrvGetType();
+        internal static extern nuint StrvGetType();
     }
 }

--- a/Libs/GObject-2.0/Records/Value.cs
+++ b/Libs/GObject-2.0/Records/Value.cs
@@ -40,7 +40,7 @@ namespace GObject
 
         internal Native.Value.Struct GetData() => Marshal.PtrToStructure<Native.Value.Struct>(Handle.DangerousGetHandle());
         
-        private ulong GetTypeValue()
+        private nuint GetTypeValue()
         {
             var structure = Marshal.PtrToStructure<Native.Value.Struct>(Handle.DangerousGetHandle());
             return structure.GType;
@@ -124,32 +124,32 @@ namespace GObject
         public object? Extract()
         {
             var type = GetTypeValue();
-            return (Types) type switch
+            return type switch
             {
-                Types.Boolean => GetBool(),
-                Types.UInt => GetUint(),
-                Types.Int => GetInt(),
-                Types.Long => GetLong(),
-                Types.Double => GetDouble(),
-                Types.Float => GetFloat(),
-                Types.String => GetString(),
-                Types.Pointer => GetPtr(),
+                (nuint) BasicTypes.Boolean => GetBool(),
+                (nuint) BasicTypes.UInt => GetUint(),
+                (nuint) BasicTypes.Int => GetInt(),
+                (nuint) BasicTypes.Long => GetLong(),
+                (nuint) BasicTypes.Double => GetDouble(),
+                (nuint) BasicTypes.Float => GetFloat(),
+                (nuint) BasicTypes.String => GetString(),
+                (nuint) BasicTypes.Pointer => GetPtr(),
                 _ => CheckComplexTypes(type)
             };
         }
 
-        private object? CheckComplexTypes(ulong gtype)
+        private object? CheckComplexTypes(nuint gtype)
         {
-            if (Functions.TypeIsA(gtype, Types.Object))
+            if (Functions.TypeIsA(gtype,(nuint) BasicTypes.Object))
                 return GetObject();
 
-            if (Functions.TypeIsA(gtype, Types.Boxed))
+            if (Functions.TypeIsA(gtype, (nuint) BasicTypes.Boxed))
                 return GetBoxed(gtype);
 
-            if (Functions.TypeIsA(gtype, Types.Enum))
+            if (Functions.TypeIsA(gtype, (nuint) BasicTypes.Enum))
                 return GetEnum();
 
-            if (Functions.TypeIsA(gtype, Types.Flags))
+            if (Functions.TypeIsA(gtype, (nuint) BasicTypes.Flags))
                 return GetFlags();
 
             throw new NotSupportedException($"Unable to extract the value to the given type. The type {gtype} is unknown.");

--- a/Libs/GObject-2.0/Structs/Type.cs
+++ b/Libs/GObject-2.0/Structs/Type.cs
@@ -10,42 +10,42 @@ namespace GObject
     {
         #region Fields
 
-        [FieldOffset(0)] private readonly ulong _value;
+        [FieldOffset(0)] private readonly nuint _value;
 
-        public ulong Value => _value;
+        public nuint Value => _value;
 
         #endregion
 
         #region Statics
 
-        public static readonly Type Invalid = new Type((ulong) Types.Invalid);
-        public static readonly Type None = new Type((ulong) Types.None);
-        public static readonly Type Interface = new Type((ulong) Types.Interface);
-        public static readonly Type Char = new Type((ulong) Types.Char);
-        public static readonly Type UChar = new Type((ulong) Types.UChar);
-        public static readonly Type Boolean = new Type((ulong) Types.Boolean);
-        public static readonly Type Int = new Type((ulong) Types.Int);
-        public static readonly Type UInt = new Type((ulong) Types.UInt);
-        public static readonly Type Long = new Type((ulong) Types.Long);
-        public static readonly Type ULong = new Type((ulong) Types.ULong);
-        public static readonly Type Int64 = new Type((ulong) Types.Int64);
-        public static readonly Type UInt64 = new Type((ulong) Types.UInt64);
-        public static readonly Type Enum = new Type((ulong) Types.Enum);
-        public static readonly Type Flags = new Type((ulong) Types.Flags);
-        public static readonly Type Float = new Type((ulong) Types.Float);
-        public static readonly Type Double = new Type((ulong) Types.Double);
-        public static readonly Type String = new Type((ulong) Types.String);
-        public static readonly Type Pointer = new Type((ulong) Types.Pointer);
-        public static readonly Type Boxed = new Type((ulong) Types.Boxed);
-        public static readonly Type Param = new Type((ulong) Types.Param);
-        public static readonly Type Object = new Type((ulong) Types.Object);
-        public static readonly Type Variant = new Type((ulong) Types.Variant);
+        public static readonly Type Invalid = new Type((nuint) BasicTypes.Invalid);
+        public static readonly Type None = new Type((nuint) BasicTypes.None);
+        public static readonly Type Interface = new Type((nuint) BasicTypes.Interface);
+        public static readonly Type Char = new Type((nuint) BasicTypes.Char);
+        public static readonly Type UChar = new Type((nuint) BasicTypes.UChar);
+        public static readonly Type Boolean = new Type((nuint) BasicTypes.Boolean);
+        public static readonly Type Int = new Type((nuint) BasicTypes.Int);
+        public static readonly Type UInt = new Type((nuint) BasicTypes.UInt);
+        public static readonly Type Long = new Type((nuint) BasicTypes.Long);
+        public static readonly Type ULong = new Type((nuint) BasicTypes.ULong);
+        public static readonly Type Int64 = new Type((nuint) BasicTypes.Int64);
+        public static readonly Type UInt64 = new Type((nuint) BasicTypes.UInt64);
+        public static readonly Type Enum = new Type((nuint) BasicTypes.Enum);
+        public static readonly Type Flags = new Type((nuint) BasicTypes.Flags);
+        public static readonly Type Float = new Type((nuint) BasicTypes.Float);
+        public static readonly Type Double = new Type((nuint) BasicTypes.Double);
+        public static readonly Type String = new Type((nuint) BasicTypes.String);
+        public static readonly Type Pointer = new Type((nuint) BasicTypes.Pointer);
+        public static readonly Type Boxed = new Type((nuint) BasicTypes.Boxed);
+        public static readonly Type Param = new Type((nuint) BasicTypes.Param);
+        public static readonly Type Object = new Type((nuint) BasicTypes.Object);
+        public static readonly Type Variant = new Type((nuint) BasicTypes.Variant);
 
         #endregion Statics
 
         #region Constructors
 
-        public Type(ulong value)
+        public Type(nuint value)
         {
             _value = value;
         }
@@ -61,7 +61,7 @@ namespace GObject
         //Offsets see: https://gitlab.gnome.org/GNOME/glib/blob/master/gobject/gtype.h
     }
 
-    internal enum Types : ulong
+    internal enum BasicTypes
     {
         Invalid = 0 << 2,
         None = 1 << 2,

--- a/Repository/Factories/Model/ClassFactory.cs
+++ b/Repository/Factories/Model/ClassFactory.cs
@@ -44,7 +44,7 @@ namespace Repository.Factories
                 implements: _symbolReferenceFactory.Create(cls.Implements, @namespace.Name),
                 methods: _methodFactory.Create(cls.Methods, @namespace),
                 functions: _methodFactory.Create(cls.Functions, @namespace),
-                getTypeFunction: _methodFactory.CreateGetTypeMethod(cls.GetTypeFunction, @namespace),
+                getTypeFunction: _methodFactory.CreateGetTypeMethod(cls.GetTypeFunction),
                 properties: _propertyFactory.Create(cls.Properties, @namespace.Name),
                 fields: _fieldFactory.Create(cls.Fields, @namespace),
                 signals: _signalFactory.Create(cls.Signals, @namespace.Name),

--- a/Repository/Factories/Model/InterfaceFactory.cs
+++ b/Repository/Factories/Model/InterfaceFactory.cs
@@ -41,7 +41,7 @@ namespace Repository.Factories
                 implements: _symbolReferenceFactory.Create(iface.Implements, @namespace.Name),
                 methods: _methodFactory.Create(iface.Methods, @namespace),
                 functions: _methodFactory.Create(iface.Functions, @namespace),
-                getTypeFunction: _methodFactory.CreateGetTypeMethod(iface.GetTypeFunction, @namespace),
+                getTypeFunction: _methodFactory.CreateGetTypeMethod(iface.GetTypeFunction),
                 properties: _propertyFactory.Create(iface.Properties, @namespace.Name)
             );
         }

--- a/Repository/Factories/Model/MethodFactory.cs
+++ b/Repository/Factories/Model/MethodFactory.cs
@@ -49,13 +49,13 @@ namespace Repository.Factories
 
         }
 
-        public Method CreateGetTypeMethod(string getTypeMethodName, Namespace @namespace)
+        public Method CreateGetTypeMethod(string getTypeMethodName)
         {
             ReturnValue returnValue = _returnValueFactory.Create(
-                type: "gulong",
+                type: "GType",
                 transfer: Transfer.None,
                 nullable: false,
-                namespaceName: @namespace.Name
+                namespaceName: new NamespaceName("GLib")
             );
 
             return new Method(

--- a/Repository/Factories/Model/RecordFactory.cs
+++ b/Repository/Factories/Model/RecordFactory.cs
@@ -26,7 +26,7 @@ namespace Repository.Factories
 
             Method? getTypeFunction = @record.GetTypeFunction switch
             {
-                { } f => _methodFactory.CreateGetTypeMethod(f, @namespace),
+                { } f => _methodFactory.CreateGetTypeMethod(f),
                 _ => null
             };
 

--- a/Repository/Factories/Model/UnionFactory.cs
+++ b/Repository/Factories/Model/UnionFactory.cs
@@ -26,7 +26,7 @@ namespace Repository.Factories
 
             Method? getTypeFunction = unionInfo.GetTypeFunction switch
             {
-                { } f => _methodFactory.CreateGetTypeMethod(f, @namespace),
+                { } f => _methodFactory.CreateGetTypeMethod(f),
                 _ => null
             };
 

--- a/Repository/Services/TypeReferenceResolverService.cs
+++ b/Repository/Services/TypeReferenceResolverService.cs
@@ -107,7 +107,7 @@ namespace Repository.Services
             symbolDictionary.AddSymbol(new PrimitiveValueType("goffset", "long"));
             symbolDictionary.AddSymbol(new PrimitiveValueType("time_t", "long"));
 
-            symbolDictionary.AddSymbol(new PrimitiveValueType("gsize", "ulong"));
+            symbolDictionary.AddSymbol(new PrimitiveValueType("gsize", "nuint"));
             symbolDictionary.AddSymbol(new PrimitiveValueType("guint64", "ulong"));
             symbolDictionary.AddSymbol(new PrimitiveValueType("gulong", "ulong"));
 


### PR DESCRIPTION
According to glib documentation [gsize](https://developer.gnome.org/glib/stable/glib-Basic-Types.html#gsize) datatype is dependent on the underlying system architecture (x86 / x64). 

To address those kind of issues C#9 introduces the primitive datatype `nint` `nuint`. See the following blog post for an overview: https://developers.redhat.com/blog/2021/04/27/some-more-c-9/

This PR changes the datatype of `gsize` to `nuint` to reflect the documentation. The alias `GType` resolves into `gsize`. For this reason the code regarding `GType` must be adopted, too.