### PR TITLE
Fix/documentation generation

### DIFF
--- a/Generator/Extensions/FieldsExtension.cs
+++ b/Generator/Extensions/FieldsExtension.cs
@@ -36,7 +36,7 @@ namespace Generator
 
             foreach (Field field in fields)
             {
-                builder.AppendLine("[FieldOffset(0)]");
+                builder.AppendLine("//[FieldOffset(0)] TODO Enable offset");
                 builder.AppendLine(field.WriteNative(currentNamespace));
             }
 

--- a/Generator/Templates/union.native.struct.sbntxt
+++ b/Generator/Templates/union.native.struct.sbntxt
@@ -1,4 +1,5 @@
-[StructLayout(LayoutKind.Explicit)]
+//TODO: Enable explicit union generation
+//[StructLayout(LayoutKind.Explicit)]
 public partial struct {{ get_metadata "PureName" }}
 {
     {{ include 'union.native.struct.fields.sbntxt' }}

--- a/Generator/Templates/union.native.struct.sbntxt
+++ b/Generator/Templates/union.native.struct.sbntxt
@@ -1,4 +1,4 @@
-//TODO: Enable explicit union generation
+//TODO: Enable explicit union generation if it does not break documentation generation anymore
 //[StructLayout(LayoutKind.Explicit)]
 public partial struct {{ get_metadata "PureName" }}
 {


### PR DESCRIPTION
Currently explicit union generation breaks the documentation generation as it missaligns some union fields.

Enable again after fixing the error.