### PR TITLE
Generator: Differentiate between pointed / unpointed records

### DIFF
--- a/GirLoader/Output/Model/TypeInformationFactory.cs
+++ b/GirLoader/Output/Model/TypeInformationFactory.cs
@@ -38,7 +38,7 @@ namespace GirLoader.Output.Model
             return anyType switch
             {
                 { Type: { } t } => GetIsPointer(t.Name, t.CType),
-                { Array: { Type: { } t } a } => GetIsPointer(string.Empty, a.CType) || GetIsPointer(t.Name, t.CType),
+                { Array: { Type: { } t } } => GetIsPointer(t.Name, t.CType),
                 { Array: { SubArray: { } } } => true,
                 Input.Model.Field { Callback: { } } => false, //Callbacks are no pointer as they are handled as delegates
                 _ => throw new Exception("Can not get pointer information from type: " + anyType)

--- a/Libs/GObject-2.0/Classes/Object.cs
+++ b/Libs/GObject-2.0/Classes/Object.cs
@@ -47,7 +47,7 @@ namespace GObject
                 objectType: gtype.Value,
                 nProperties: (uint) constructArguments.Length,
                 names: GetNames(constructArguments),
-                values: GetValues(constructArguments).Select(x => x.DangerousGetHandle()).ToArray()
+                values: GetValues(constructArguments)
             );
 
             _handle = new ObjectHandle(handle, this, !Native.Object.Instance.Methods.IsFloating(handle));
@@ -58,7 +58,7 @@ namespace GObject
         private string[] GetNames(ConstructArgument[] constructParameters)
             => constructParameters.Select(x => x.Name).ToArray();
 
-        private Native.Value.Handle[] GetValues(ConstructArgument[] constructParameters)
+        private Native.Value.Struct[] GetValues(ConstructArgument[] constructParameters)
         {
             var values = new Native.Value.Struct[constructParameters.Length];
 
@@ -67,7 +67,7 @@ namespace GObject
                 values[i] = constructParameters[i].Value.GetData();
             }
 
-            return values.Select(val => Native.Value.ManagedHandle.Create(val)).ToArray();
+            return values;
         }
 
         /// <summary>

--- a/Libs/GObject-2.0/Delegates/ClosureMarshalCallbackWorkaround.cs
+++ b/Libs/GObject-2.0/Delegates/ClosureMarshalCallbackWorkaround.cs
@@ -19,7 +19,7 @@ namespace GObject
             _managedCallback = managed;
         }
 
-        private void NativeCallbackMarshaller(IntPtr closure, IntPtr returnValue, uint nParamValues, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] IntPtr[] paramValues, IntPtr invocationHint, IntPtr marshalData)
+        private void NativeCallbackMarshaller(IntPtr closure, IntPtr returnValue, uint nParamValues, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] Native.Value.Struct[] paramValues, IntPtr invocationHint, IntPtr marshalData)
         {
             _managedCallback();
         }

--- a/Tests/Libs/Gtk-3.0.Tests/ConstructorTest.cs
+++ b/Tests/Libs/Gtk-3.0.Tests/ConstructorTest.cs
@@ -1,0 +1,18 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Gtk.Tests
+{
+    [TestClass, TestCategory("SystemTest")]
+    public class ConstructorTest
+    {
+        [TestMethod]
+        public void WindowConstructorShouldSetTitle()
+        {
+            var title = "MyTitle";
+            var window = new Window(title);
+
+            window.Title.Should().Be(title);
+        }
+    }
+}


### PR DESCRIPTION
Unpointed records (value based)
* For non array records in the gir their original record structure must be used.
* For arrays of records in the gir their original record structure must be used inside an array.

Pointed records (pointer based)
* For non array records in the gir a pointer must be used. This could either be an SafeHandle (regular case) or an IntPtr (e.g. in case of free methods).
* For arrays of records always IntPtr[] must be used as arrays of SafeHandles are not supported by the runtime.

The method and delegate generators currently do not differentiate between pointed and unpointed records. To avoid compilation errors those cases are currently passing default values to methods and marked with a TODO flag.

This fixes the window sample.