### PR TITLE
Fix Generator on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,28 @@ on:
   pull_request:
 
 jobs:
+  compile:
+    name: Compile
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+    
+    steps:
+      - name: Checkout with submodules
+        uses: actions/checkout@v2.3.4
+        with: 
+          submodules: 'true'
+
+      - name: Prepare .NET
+        uses: actions/setup-dotnet@v1.8.0
+        with:
+          dotnet-version: '5.0.x'
+
+      - name: Run release build (no tests)
+        run: dotnet run -- --release --xml-documentation --targets unitTest samples
+        working-directory: './Build'
+  
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/GirLoader/Output/Loader.cs
+++ b/GirLoader/Output/Loader.cs
@@ -19,17 +19,17 @@ namespace GirLoader.Output
             Log.Information($"Initialising with {files.Count()} toplevel project(s)");
 
             var repositories = files.Select(_repositoryLoader.LoadRepository);
-            ResolveRepositories(repositories);
+            repositories = ResolveRepositories(repositories);
 
             return repositories;
         }
 
-        private void ResolveRepositories(IEnumerable<Model.Repository> repositories)
+        private IEnumerable<Model.Repository> ResolveRepositories(IEnumerable<Model.Repository> repositories)
         {
             foreach (var repository in repositories)
                 _repositoryResolver.Add(repository);
 
-            _repositoryResolver.Resolve();
+            return _repositoryResolver.Resolve();
         }
     }
 }

--- a/GirLoader/Output/RepositoryResolver.cs
+++ b/GirLoader/Output/RepositoryResolver.cs
@@ -93,13 +93,16 @@ namespace GirLoader.Output
         /// <summary>
         /// Resolves all loaded repositories
         /// </summary>
-        public void Resolve()
+        public IEnumerable<Model.Repository> Resolve()
         {
             var dependencyResolver = new Helper.DependencyResolver<Model.Repository>();
             var orderedRepositories = dependencyResolver.ResolveOrdered(_knownRepositories).Cast<Model.Repository>();
 
             foreach (var repository in orderedRepositories)
+            {
                 ResolveTypeReferences(repository.Namespace);
+                yield return repository;
+            }
         }
 
         private void FillTypeDictionary(Model.Namespace @namespace)
@@ -123,6 +126,9 @@ namespace GirLoader.Output
 
         private void ResolveTypeReference(Model.TypeReference reference)
         {
+            if (reference.TypeName == "PixbufFormat")
+                System.Console.WriteLine("hello?");
+
             if (_typeDictionary.TryLookup(reference, out var type))
                 reference.ResolveAs(type);
         }

--- a/GirLoader/Output/RepositoryResolver.cs
+++ b/GirLoader/Output/RepositoryResolver.cs
@@ -126,9 +126,6 @@ namespace GirLoader.Output
 
         private void ResolveTypeReference(Model.TypeReference reference)
         {
-            if (reference.TypeName == "PixbufFormat")
-                System.Console.WriteLine("hello?");
-
             if (_typeDictionary.TryLookup(reference, out var type))
                 reference.ResolveAs(type);
         }


### PR DESCRIPTION
For some reason, the generator has stopped working on Windows (despite working on Linux and containing no platform-specific code). This change really shouldn't make a difference, but somehow it does. Perhaps we've encountered a runtime bug?

This PR:
 - Changes how we handle Repository to make the generator work again
 - Adds CI Matrix builds for Windows and MacOS