### PR TITLE
Allow Namespace class to be filled from a caller.

### DIFF
--- a/src/Generation/GirLoader/Helper/RepositoryDependencyResolver.cs
+++ b/src/Generation/GirLoader/Helper/RepositoryDependencyResolver.cs
@@ -3,24 +3,19 @@ using System.Collections.Generic;
 
 namespace GirLoader.Helper
 {
-    internal interface Node<out T> where T : Node<T>
-    {
-        public IEnumerable<T> Dependencies { get; }
-    }
-
     // Dependency Resolver Algorithm
     // https://www.electricmonk.nl/docs/dependency_resolving_algorithm/dependency_resolving_algorithm.html
-    internal class DependencyResolver<T> where T : Node<T>
+    internal class RepositoryDependencyResolver
     {
-        private List<Node<T>> _resolvedNodes = new();
-        private List<Node<T>> _unresolvedNodes = new();
+        private List<Output.Repository> _resolvedNodes = new();
+        private List<Output.Repository> _unresolvedNodes = new();
 
-        public IEnumerable<Node<T>> ResolveOrdered(IEnumerable<Node<T>> nodeList)
+        public IEnumerable<Output.Repository> ResolveOrdered(IEnumerable<Output.Repository> nodeList)
         {
-            _resolvedNodes = new List<Node<T>>();
-            _unresolvedNodes = new List<Node<T>>();
+            _resolvedNodes = new List<Output.Repository>();
+            _unresolvedNodes = new List<Output.Repository>();
 
-            foreach (Node<T> node in nodeList)
+            foreach (Output.Repository node in nodeList)
             {
                 if (!_resolvedNodes.Contains(node))
                     ResolveDependenciesRecursive(node);
@@ -29,11 +24,11 @@ namespace GirLoader.Helper
             return _resolvedNodes;
         }
 
-        private void ResolveDependenciesRecursive(Node<T> node)
+        private void ResolveDependenciesRecursive(Output.Repository node)
         {
             _unresolvedNodes.Add(node);
 
-            foreach (T dep in node.Dependencies)
+            foreach (Output.Repository dep in node.Dependencies)
             {
                 if (_resolvedNodes.Contains(dep))
                     continue;

--- a/src/Generation/GirLoader/Output/Repository.cs
+++ b/src/Generation/GirLoader/Output/Repository.cs
@@ -1,18 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GirLoader.Helper;
 
 namespace GirLoader.Output
 {
-    public class Repository : Node<Repository>
+    public class Repository
     {
         private Namespace? _namespace;
         public Namespace Namespace => _namespace ?? throw new Exception("Namespace not initialized.");
-        public IEnumerable<Include> Includes { get; }
-        public IEnumerable<Repository> Dependencies => Includes.Select(x => x.GetResolvedRepository());
+        internal IEnumerable<Include> Includes { get; }
+        internal IEnumerable<Repository> Dependencies => Includes.Select(x => x.GetResolvedRepository());
 
-        public Repository(IEnumerable<Include> includes)
+        public Repository() : this(Enumerable.Empty<Include>()){ }
+        
+        internal Repository(IEnumerable<Include> includes)
         {
             Includes = includes;
         }

--- a/src/Generation/GirLoader/RepositoryConverter.cs
+++ b/src/Generation/GirLoader/RepositoryConverter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace GirLoader
 {
@@ -41,7 +42,8 @@ namespace GirLoader
 
         private Output.Repository LoadRepository(Output.Include include)
         {
-            var includeFileInfo = _resolveInclude(include);
+            var includeFileInfo = _resolveInclude(include) ?? throw new Exception($"Could not resolve include {include.Name}");
+
             return LoadRepository(includeFileInfo);
         }
     }

--- a/src/Generation/GirLoader/RepositoryResolver.cs
+++ b/src/Generation/GirLoader/RepositoryResolver.cs
@@ -28,7 +28,7 @@ namespace GirLoader
         /// </summary>
         public void Resolve()
         {
-            var dependencyResolver = new Helper.DependencyResolver<Output.Repository>();
+            var dependencyResolver = new Helper.RepositoryDependencyResolver();
             var orderedRepositories = dependencyResolver.ResolveOrdered(_knownRepositories).Cast<Output.Repository>();
 
             foreach (var repository in orderedRepositories)


### PR DESCRIPTION
This is necessary to be able to create unit tests for the generator to create test scenarios.

The properties are set to init only. An update of the properties after the object creation is not possible like before.