### PR TITLE
Make code a bit more NativeAOT friendly

### DIFF
--- a/src/Generation/Generator/Templates/native.safehandle.sbntxt
+++ b/src/Generation/Generator/Templates/native.safehandle.sbntxt
@@ -42,12 +42,12 @@ namespace {{ namespace.native_name }}
                 
                 if (data.HasValue)
                 {
-                    Marshal.StructureToPtr(data.Value, ptr, false);
+                    Marshal.StructureToPtr<{{$struct_name}}>(data.Value, ptr, false);
                 }
                 else
                 {
                     var str = new {{$struct_name}}();
-                    Marshal.StructureToPtr(str, ptr, false);
+                    Marshal.StructureToPtr<{{$struct_name}}>(str, ptr, false);
                 }
                 
                 return new Managed{{$safehandle_name}}(ptr);

--- a/src/Libs/GLib-2.0/Classes/MarshalHelper.cs
+++ b/src/Libs/GLib-2.0/Classes/MarshalHelper.cs
@@ -8,10 +8,10 @@ namespace GLib
         public static K ToPtrAndFree<T, K>(T structure, Func<IntPtr, K> action) where T : struct
         {
             K result;
-            IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(structure));
+            IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf<T>());
             try
             {
-                Marshal.StructureToPtr(structure, ptr, false);
+                Marshal.StructureToPtr<T>(structure, ptr, false);
                 result = action(ptr);
             }
             finally
@@ -24,10 +24,10 @@ namespace GLib
 
         public static void ToPtrAndFree<T>(T structure, Action<IntPtr> action) where T : struct
         {
-            IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(structure));
+            IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf<T>());
             try
             {
-                Marshal.StructureToPtr(structure, ptr, false);
+                Marshal.StructureToPtr<T>(structure, ptr, false);
                 action(ptr);
             }
             finally

--- a/src/Libs/GObject-2.0/Records/Closure.cs
+++ b/src/Libs/GObject-2.0/Records/Closure.cs
@@ -15,7 +15,7 @@ namespace GObject
         internal Closure(ClosureMarshal action)
         {
             _closureMarshalCallHandler = new ClosureMarshalCallHandler(action);
-            _handle = Native.Closure.Methods.NewSimple((uint) Marshal.SizeOf(typeof(GObject.Native.Closure.Struct)), IntPtr.Zero);
+            _handle = Native.Closure.Methods.NewSimple((uint) Marshal.SizeOf<GObject.Native.Closure.Struct>(), IntPtr.Zero);
 
             Debug.WriteLine($"Instantiating Closure: Address {_handle.DangerousGetHandle()}.");
 

--- a/src/Libs/Gst-1.0/Classes/Pad.cs
+++ b/src/Libs/Gst-1.0/Classes/Pad.cs
@@ -42,8 +42,8 @@ namespace Gst
             IntPtr ptr = IntPtr.Zero;
             if (filter != null)
             {
-                ptr = Marshal.AllocHGlobal(Marshal.SizeOf(filter));
-                Marshal.StructureToPtr(filter, ptr, false);
+                ptr = Marshal.AllocHGlobal(Marshal.SizeOf<Caps>());
+                Marshal.StructureToPtr<Caps>(filter, ptr, false);
             }
 
             throw new NotImplementedException(); //TODO
@@ -52,7 +52,7 @@ namespace Gst
             //Marshal.FreeHGlobal(ptr);
 
             // TODO: Should/can this return null?
-            //return (Caps?) Marshal.PtrToStructure(ret, typeof(Caps));
+            //return Marshal.PtrToStructure<Caps>(ret);
         }*/
     }
 }

--- a/src/Libs/Gst-1.0/Records/Message.cs
+++ b/src/Libs/Gst-1.0/Records/Message.cs
@@ -28,14 +28,14 @@ namespace Gst
         public Structure GetStructure()
         {
             // Marshal this structure
-            IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<Message>());
+            Marshal.StructureToPtr<Message>(this, thisPtr, false);
 
             IntPtr ptr = Native.get_structure(thisPtr);
 
             // Update this structure (is this necessary?)
             // TODO: Check for NULL
-            this = (Message) Marshal.PtrToStructure(thisPtr, GetType())!;
+            this = Marshal.PtrToStructure<Message>(thisPtr)!;
 
             Marshal.FreeHGlobal(thisPtr);
 
@@ -51,13 +51,13 @@ namespace Gst
             IntPtr oldStatePtr = default, newStatePtr = default, pendingStatePtr = default;
 
             // Marshal this structure
-            IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<Message>());
+            Marshal.StructureToPtr<Message>(this, thisPtr, false);
 
             Native.parse_state_changed(thisPtr, out oldStatePtr, out newStatePtr, out pendingStatePtr);
 
             // Update and free (TODO: Check for NULL)
-            this = (Message) Marshal.PtrToStructure(thisPtr, GetType())!;
+            this = Marshal.PtrToStructure<Message>(thisPtr)!;
             Marshal.FreeHGlobal(thisPtr);
 
             // Assign out variables
@@ -75,13 +75,13 @@ namespace Gst
             IntPtr tagListPtr = default;
 
             // Marshal this structure
-            IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<Message>());
+            Marshal.StructureToPtr<Message>(this, thisPtr, false);
 
             Native.parse_tag(thisPtr, out tagListPtr);
 
             // Update and free (TODO: Check for NULL)
-            this = (Message) Marshal.PtrToStructure(thisPtr, GetType())!;
+            this = Marshal.PtrToStructure<Message>(thisPtr)!;
             Marshal.FreeHGlobal(thisPtr);
 
             // Assign out variables
@@ -97,13 +97,13 @@ namespace Gst
             percent = 0;
 
             // Marshal this structure
-            IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<Message>());
+            Marshal.StructureToPtr<Message>(this, thisPtr, false);
 
             Native.parse_buffering(thisPtr, out percent);
 
             // Update and free (TODO: Check for NULL)
-            this = (Message) Marshal.PtrToStructure(thisPtr, GetType())!;
+            this = Marshal.PtrToStructure<Message>(thisPtr)!;
             Marshal.FreeHGlobal(thisPtr);
         }
 
@@ -115,13 +115,13 @@ namespace Gst
             // Empty pointers
 
             // Marshal this structure
-            IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<Message>());
+            Marshal.StructureToPtr<Message>(this, thisPtr, false);
 
             Native.parse_error(thisPtr, out IntPtr errPtr, out IntPtr strPtr);
 
             // Update and free (TODO: Check for NULL)
-            this = (Message) Marshal.PtrToStructure(thisPtr, GetType())!;
+            this = Marshal.PtrToStructure<Message>(thisPtr)!;
             debug = StringHelper.ToNullableAnsiStringAndFree(strPtr);
             error = Marshal.PtrToStructure<GLib.Error>(errPtr);
             Marshal.FreeHGlobal(thisPtr);

--- a/src/Libs/Gst-1.0/Records/Structure.cs
+++ b/src/Libs/Gst-1.0/Records/Structure.cs
@@ -10,8 +10,8 @@ namespace Gst
             throw new NotImplementedException(); //TODO
 
             // Marshal this structure
-            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<Structure>());
+            Marshal.StructureToPtr<Structure>(this, thisPtr, false);
 
             // Do not free result as ownership is not transferred!
             IntPtr result = Native.get_name(thisPtr);
@@ -28,13 +28,13 @@ namespace Gst
             throw new NotImplementedException(); //TODO
 
             // Marshal this structure
-            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<Structure>());
+            Marshal.StructureToPtr<Structure>(this, thisPtr, false);
 
             Native.set_name(thisPtr, structureName);
 
             // Update this structure (TODO: Check for NULL)
-            this = (Structure) Marshal.PtrToStructure(thisPtr, GetType())!;*/
+            this = Marshal.PtrToStructure<Structure>(thisPtr)!;*/
         }
     }
 }

--- a/src/Libs/Gst-1.0/Records/TagList.cs
+++ b/src/Libs/Gst-1.0/Records/TagList.cs
@@ -10,13 +10,13 @@ namespace Gst
         {
             throw new NotImplementedException(); //TODO
             // Marshal this structure
-            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<TagList>());
+            Marshal.StructureToPtr<TagList>(this, thisPtr, false);
 
             Native.@foreach(thisPtr, func, IntPtr.Zero);
 
             // Update this structure (TODO: Check for NULL)
-            this = (TagList) Marshal.PtrToStructure(thisPtr, GetType())!;*/
+            this = Marshal.PtrToStructure<TagList>(thisPtr)!;*/
         }
 
         public void Add(TagMergeMode mode, string tag, params Value[] values)
@@ -31,13 +31,13 @@ namespace Gst
         {
             throw new NotImplementedException(); //TODO
             // Marshal this structure
-            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<TagList>());
+            Marshal.StructureToPtr<TagList>(this, thisPtr, false);
 
             Native.add_value(thisPtr, mode, tag, ref value);
 
             // Update this structure (TODO: Check for NULL)
-            this = (TagList) Marshal.PtrToStructure(thisPtr, GetType())!;
+            this = Marshal.PtrToStructure<TagList>(thisPtr)!;
 
             // Dispose of Value afterwards
             value.Dispose();*/
@@ -47,13 +47,13 @@ namespace Gst
         {
             throw new NotImplementedException(); //TODO
             // Marshal this structure
-            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<TagList>());
+            Marshal.StructureToPtr<TagList>(this, thisPtr, false);
 
             var result = Native.get_tag_size(thisPtr, tag);
 
             // Update this structure (TODO: Check for NULL)
-            this = (TagList) Marshal.PtrToStructure(thisPtr, GetType())!;
+            this = Marshal.PtrToStructure<TagList>(thisPtr)!;
 
             return result;*/
         }
@@ -62,13 +62,13 @@ namespace Gst
         {
             throw new NotImplementedException(); //TODO
             // Marshal this structure
-            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(this));
-            Marshal.StructureToPtr(this, thisPtr, false);
+            /*IntPtr thisPtr = Marshal.AllocHGlobal(Marshal.SizeOf<TagList>());
+            Marshal.StructureToPtr<TagList>(this, thisPtr, false);
 
             var result = Native.get_value_index(thisPtr, tag, index);
 
             // Update this structure (TODO: Check for NULL)
-            this = (TagList) Marshal.PtrToStructure(thisPtr, GetType())!;
+            this = Marshal.PtrToStructure<TagList>(thisPtr)!;
 
             return result;*/
         }

--- a/src/Libs/GstPbutils-1.0/Classes/Global.cs
+++ b/src/Libs/GstPbutils-1.0/Classes/Global.cs
@@ -14,7 +14,7 @@ namespace GstPbutils
             //     var result = Native.is_missing_plugin_message(msgPtr);
             //
             //     // Update this structure
-            //     Marshal.PtrToStructure(msgPtr, msg);
+            //     Marshal.PtrToStructure<Gst.Message>(msgPtr, msg);
             //
             //     return result;
             // });
@@ -28,7 +28,7 @@ namespace GstPbutils
             //     IntPtr result = Native.missing_plugin_message_get_installer_detail(msgPtr);
             //
             //     // Update this structure
-            //     Marshal.PtrToStructure(msgPtr, msg);
+            //     Marshal.PtrToStructure<Gst.Message>(msgPtr, msg);
             //
             //     return StringHelper.ToAnsiStringAndFree(result);
             // });
@@ -42,7 +42,7 @@ namespace GstPbutils
             //     IntPtr result = Native.missing_plugin_message_get_description(msgPtr);
             //
             //     // Update this structure
-            //     Marshal.PtrToStructure(msgPtr, msg);
+            //     Marshal.PtrToStructure<Gst.Message>(msgPtr, msg);
             //
             //     return StringHelper.ToAnsiStringAndFree(result);
             // });

--- a/src/Libs/GstVideo-1.0/Interfaces/Navigation.cs
+++ b/src/Libs/GstVideo-1.0/Interfaces/Navigation.cs
@@ -32,7 +32,7 @@ namespace GstVideo
             //
             //     // Update message structure
             //     // TODO: Not necessary?
-            //     Marshal.PtrToStructure(messagePtr, message);
+            //     Marshal.PtrToStructure<Message>(messagePtr, message);
             //
             //     return result;
             // });


### PR DESCRIPTION
I update where can
- `Marshal.SizeOf(Type)` replaced with `Marshal.SizeOt<T>()`
- `Marshal.PtrToStructure(IntrPtr, Type)` replaced with `Marshal.PtrToStructure<T>(IntPtr)`
- `Marshal.StructureToPtr(object, IntPtr, bool)` replaced with `Marshal.StructureToPtr<T>(T, IntPtr, bool)`

This update change codegeneration piece and commented code,
since in case somebody willing to make that code works,
I would like that this part would not slip between cracks.