### PR TITLE
Validate constants

### DIFF
--- a/src/Generation/Generator3/Generation/Constants/Model.cs
+++ b/src/Generation/Generator3/Generation/Constants/Model.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 using Generator3.Model.Public;
 
 namespace Generator3.Generation.Constants
@@ -16,9 +17,50 @@ namespace Generator3.Generation.Constants
             _constants = constants;
 
             Constants = constants
+                .Where(IsValid)
                 .Select(constant => new Constant(constant))
                 .ToList();
         }
 
+        private bool IsValid(GirModel.Constant constant)
+        {
+            switch (constant.Type)
+            {
+                case GirModel.PrimitiveType:
+                    return IsValidPrimitiveType(constant);
+                case GirModel.Bitfield:
+                    return true;
+                default:
+                    Log.Warning($"Excluding {constant.Namespace} constant '{constant.Name}'. Can't assign value '{constant.Value}' to unsupported type '{constant.Type.GetName()}'.");
+                    return false;
+            }
+        }
+
+        private bool IsValidPrimitiveType(GirModel.Constant constant)
+        {
+            var canParse = constant.Type switch
+            {
+                GirModel.Bool => bool.TryParse(constant.Value, out _),
+                GirModel.Byte => byte.TryParse(constant.Value, out _),
+                GirModel.Double => double.TryParse(constant.Value, out _),
+                GirModel.Integer => int.TryParse(constant.Value, out _),
+                GirModel.Long => long.TryParse(constant.Value, out _),
+                GirModel.NativeUnsignedInteger => nuint.TryParse(constant.Value, out _),
+                GirModel.Short => short.TryParse(constant.Value, out _),
+                GirModel.SignedByte => sbyte.TryParse(constant.Value, out _),
+                GirModel.String => true,
+                GirModel.UnsignedInteger => uint.TryParse(constant.Value, out _),
+                GirModel.UnsignedLong => ulong.TryParse(constant.Value, out _),
+                GirModel.UnsignedShort => ushort.TryParse(constant.Value, out _),
+                _ => false
+            };
+
+            if (canParse)
+                return true;
+
+            Log.Warning($"Excluding {constant.Namespace} constant '{constant.Name}'. Can't convert value '{constant.Value}' to type '{constant.Type.GetName()}'.");
+
+            return false;
+        }
     }
 }

--- a/src/Generation/Generator3/Model/Public/Constant.cs
+++ b/src/Generation/Generator3/Model/Public/Constant.cs
@@ -19,7 +19,7 @@ namespace Generator3.Model.Public
         {
             return _constant.Type switch
             {
-                GirModel.ComplexType { Name: { } name } when name.EndsWith("Flags") => $"({name}) {_constant.Value}",
+                GirModel.Bitfield { Name: { } name } => $"({name}) {_constant.Value}",
                 GirModel.String => "\"" + _constant.Value + "\"",
                 _ => _constant.Value
             };

--- a/src/Generation/GirModel/GirModel.csproj
+++ b/src/Generation/GirModel/GirModel.csproj
@@ -3,6 +3,6 @@
     <RootNamespace>GirModule</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OneOf" Version="3.0.205" />
+    <PackageReference Include="OneOf" Version="3.0.211" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- [x] Only generate primitive constants (HarfBuzz defines a constant with a non primitive type)
- [x] Only generate integer constants if they match their given bounds (HarfBuzz defines constants which are out of bounds).

Log warning in those cases.