### PR TITLE
Refactor the manual Cairo bindings

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.cs
@@ -1,0 +1,33 @@
+﻿using System.Runtime.InteropServices;
+
+namespace cairo.Internal
+{
+    public partial class Context
+    {
+        private const string CairoLib = "cairo-graphics";
+
+        [DllImport(CairoLib, EntryPoint = "cairo_fill")]
+        public static extern void Fill(ContextHandle cr);
+
+        [DllImport(CairoLib, EntryPoint = "cairo_font_extents")]
+        public static extern void FontExtents(ContextHandle cr, out FontExtents extents);
+
+        [DllImport(CairoLib, EntryPoint = "cairo_move_to")]
+        public static extern void MoveTo(ContextHandle cr, double x, double y);
+
+        [DllImport(CairoLib, EntryPoint = "cairo_rectangle")]
+        public static extern void Rectangle(ContextHandle cr, double x, double y, double width, double height);
+
+        [DllImport(CairoLib, EntryPoint = "cairo_set_font_size")]
+        public static extern void SetFontSize(ContextHandle cr, double size);
+
+        [DllImport(CairoLib, EntryPoint = "cairo_set_source_rgba")]
+        public static extern void SetSourceRgba(ContextHandle cr, double red, double green, double blue, double alpha);
+
+        [DllImport(CairoLib, EntryPoint = "cairo_show_text")]
+        public static extern void ShowText(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8);
+
+        [DllImport(CairoLib, EntryPoint = "cairo_text_extents")]
+        public static extern void TextExtents(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8, out TextExtents extents);
+    }
+}

--- a/src/Libs/cairo-1.0/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Records/Context.cs
@@ -1,60 +1,29 @@
-﻿using System.Runtime.InteropServices;
-
-namespace cairo
+﻿namespace cairo
 {
     public partial class Context
     {
-        // IMPORTANT: We should follow cairo's guidelines on memory management
-        // for language bindings. This is a quick attempt at implementing something
-        // workable.
-
-        [DllImport("cairo-graphics", EntryPoint = "cairo_set_source_rgba")]
-        private static extern void NativeSetSourceRgba(Internal.ContextHandle cr, double red, double green, double blue, double alpha);
-
-        public void SetSourceRgba(double red, double green, double blue, double alpha)
-            => NativeSetSourceRgba(Handle, red, green, blue, alpha);
-
-        [DllImport("cairo-graphics", EntryPoint = "cairo_show_text")]
-        private static extern void NativeShowText(Internal.ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8);
-
-        public void ShowText(string text)
-            => NativeShowText(Handle, text);
-
-        [DllImport("cairo-graphics", EntryPoint = "cairo_move_to")]
-        private static extern void NativeMoveTo(Internal.ContextHandle cr, double x, double y);
-
-        public void MoveTo(double x, double y)
-            => NativeMoveTo(Handle, x, y);
-
-        [DllImport("cairo-graphics", EntryPoint = "cairo_text_extents")]
-        private static extern void NativeTextExtents(Internal.ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8, out TextExtents extents);
-
-        public void TextExtents(string text, out TextExtents extents)
-            => NativeTextExtents(Handle, text, out extents);
-
-        [DllImport("cairo-graphics", EntryPoint = "cairo_font_extents")]
-        private static extern void NativeFontExtents(Internal.ContextHandle cr, out FontExtents extents);
+        public void Fill()
+            => Internal.Context.Fill(Handle);
 
         public void FontExtents(out FontExtents extents)
-            => NativeFontExtents(Handle, out extents);
+            => Internal.Context.FontExtents(Handle, out extents);
 
-        [DllImport("cairo-graphics", EntryPoint = "cairo_fill")]
-        private static extern void NativeFill(Internal.ContextHandle cr);
-
-        public void Fill()
-            => NativeFill(Handle);
-
-        [DllImport("cairo-graphics", EntryPoint = "cairo_rectangle")]
-        private static extern void NativeRectangle(Internal.ContextHandle cr, double x, double y, double width, double height);
+        public void MoveTo(double x, double y)
+            => Internal.Context.MoveTo(Handle, x, y);
 
         public void Rectangle(double x, double y, double width, double height)
-            => NativeRectangle(Handle, x, y, width, height);
-
-
-        [DllImport("cairo-graphics", EntryPoint = "cairo_set_font_size")]
-        private static extern void NativeSetFontSize(Internal.ContextHandle cr, double size);
+            => Internal.Context.Rectangle(Handle, x, y, width, height);
 
         public void SetFontSize(double size)
-            => NativeSetFontSize(Handle, size);
+            => Internal.Context.SetFontSize(Handle, size);
+
+        public void SetSourceRgba(double red, double green, double blue, double alpha)
+            => Internal.Context.SetSourceRgba(Handle, red, green, blue, alpha);
+
+        public void ShowText(string text)
+            => Internal.Context.ShowText(Handle, text);
+
+        public void TextExtents(string text, out TextExtents extents)
+            => Internal.Context.TextExtents(Handle, text, out extents);
     }
 }


### PR DESCRIPTION
- Move the native methods into the Internal namespace to be more consistent with normal generated bindings
- Sort into alphabetical order for readability