### PR TITLE
Require a foreign record's OwnedHandle to manually implement ReleaseHandle()

### DIFF
--- a/src/Generation/Generator3/Generation/Record/InternalOwnedHandle/InternalOwnedHandleModel.cs
+++ b/src/Generation/Generator3/Generation/Record/InternalOwnedHandle/InternalOwnedHandleModel.cs
@@ -10,6 +10,7 @@ namespace Generator3.Generation.Record
         public string OwnedHandleName => Record.GetInternalOwnedHandleName();
         public string InternalNamespaceName => Record.Namespace.GetInternalName();
         public string NamespaceName => Record.Namespace.Name;
+        public bool Foreign => Record.Foreign;
         public GirModel.Record Record { get; }
         public GirModel.Method? FreeMethod => GetFreeOrUnrefMethod(Record.Methods);
 

--- a/src/Generation/Generator3/Generation/Record/InternalOwnedHandle/InternalOwnedHandleTemplate.cs
+++ b/src/Generation/Generator3/Generation/Record/InternalOwnedHandle/InternalOwnedHandleTemplate.cs
@@ -23,10 +23,7 @@ namespace { model.InternalNamespaceName }
             SetHandle(handle);
         }}
 
-        protected override bool ReleaseHandle()
-        {{
-            {model.RenderFreeCall()}
-        }}
+        {model.RenderReleaseHandle()}
 
         {model.RenderFreeFunction()}
     }}

--- a/src/Generation/Generator3/Generation/Record/InternalOwnedHandle/ReleaseHandleRenderer.cs
+++ b/src/Generation/Generator3/Generation/Record/InternalOwnedHandle/ReleaseHandleRenderer.cs
@@ -1,0 +1,24 @@
+﻿namespace Generator3.Generation.Record
+{
+    public static class ReleaseHandleRenderer
+    {
+        public static string RenderReleaseHandle(this InternalOwnedHandleModel model)
+        {
+            if (model.Foreign)
+            {
+                return $@"
+        // For foreign records, the release function must be manually implemented.
+        protected override partial bool ReleaseHandle();";
+            }
+            else
+            {
+                return $@"
+        protected override bool ReleaseHandle()
+        {{
+            {model.RenderFreeCall()}
+        }}";
+            }
+        }
+    }
+}
+

--- a/src/Libs/cairo-1.0/Internal/Framework/DllImportOverride.cs
+++ b/src/Libs/cairo-1.0/Internal/Framework/DllImportOverride.cs
@@ -16,6 +16,11 @@ namespace cairo.Internal
     {
         #region Fields
 
+        // Identifiers for libcairo / libcairo-gobject.
+        // See TryGetOsDependentLibraryName() for details of the name mapping.
+        public const string CairoLib = "cairo-graphics";
+        private const string CairoGObjectLib = "cairo";
+
         // libcairo (for manually written code)
         private const string _windowsDllName = "libcairo-2.dll";
         private const string _linuxDllName = "libcairo.so.2";
@@ -67,7 +72,7 @@ namespace cairo.Internal
 
             // Confusingly, "cairo" refers to "cairo-gobject" as this is
             // the library specified in "cairo-1.0.gir".
-            if (libraryName == "cairo")
+            if (libraryName == CairoGObjectLib)
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     osDependentLibraryName = _cgoWindowsDllName;
@@ -83,7 +88,7 @@ namespace cairo.Internal
 
             // This is the actual "libcairo" which defines the
             // functions, structs, etc that we want.
-            if (libraryName == "cairo-graphics")
+            if (libraryName == CairoLib)
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     osDependentLibraryName = _windowsDllName;

--- a/src/Libs/cairo-1.0/Internal/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.cs
@@ -4,30 +4,31 @@ namespace cairo.Internal
 {
     public partial class Context
     {
-        private const string CairoLib = "cairo-graphics";
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_destroy")]
+        public static extern void Destroy(ContextHandle handle);
 
-        [DllImport(CairoLib, EntryPoint = "cairo_fill")]
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_fill")]
         public static extern void Fill(ContextHandle cr);
 
-        [DllImport(CairoLib, EntryPoint = "cairo_font_extents")]
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_extents")]
         public static extern void FontExtents(ContextHandle cr, out FontExtents extents);
 
-        [DllImport(CairoLib, EntryPoint = "cairo_move_to")]
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_move_to")]
         public static extern void MoveTo(ContextHandle cr, double x, double y);
 
-        [DllImport(CairoLib, EntryPoint = "cairo_rectangle")]
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_rectangle")]
         public static extern void Rectangle(ContextHandle cr, double x, double y, double width, double height);
 
-        [DllImport(CairoLib, EntryPoint = "cairo_set_font_size")]
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_set_font_size")]
         public static extern void SetFontSize(ContextHandle cr, double size);
 
-        [DllImport(CairoLib, EntryPoint = "cairo_set_source_rgba")]
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_set_source_rgba")]
         public static extern void SetSourceRgba(ContextHandle cr, double red, double green, double blue, double alpha);
 
-        [DllImport(CairoLib, EntryPoint = "cairo_show_text")]
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_show_text")]
         public static extern void ShowText(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8);
 
-        [DllImport(CairoLib, EntryPoint = "cairo_text_extents")]
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_text_extents")]
         public static extern void TextExtents(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8, out TextExtents extents);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.cs
@@ -5,7 +5,7 @@ namespace cairo.Internal
     public partial class Context
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_destroy")]
-        public static extern void Destroy(ContextHandle handle);
+        public static extern void Destroy(ContextOwnedHandle handle);
 
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_fill")]
         public static extern void Fill(ContextHandle cr);

--- a/src/Libs/cairo-1.0/Internal/Records/ContextOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ContextOwnedHandle.cs
@@ -1,0 +1,12 @@
+﻿namespace cairo.Internal
+{
+    public partial class ContextOwnedHandle : ContextHandle
+    {
+        protected override partial bool ReleaseHandle()
+        {
+            Context.Destroy(this);
+            return true;
+        }
+    }
+}
+

--- a/src/Libs/cairo-1.0/Internal/Records/Device.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Device.cs
@@ -6,6 +6,6 @@ namespace cairo.Internal
     public partial class Device
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_device_destroy")]
-        public static extern void Destroy(DeviceHandle handle);
+        public static extern void Destroy(DeviceOwnedHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/Device.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Device.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace cairo.Internal
+{
+    public partial class Device
+    {
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_device_destroy")]
+        public static extern void Destroy(DeviceHandle handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/DeviceOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/DeviceOwnedHandle.cs
@@ -1,0 +1,12 @@
+﻿namespace cairo.Internal
+{
+    public partial class DeviceOwnedHandle : DeviceHandle
+    {
+        protected override partial bool ReleaseHandle()
+        {
+            Device.Destroy(this);
+            return true;
+        }
+    }
+}
+

--- a/src/Libs/cairo-1.0/Internal/Records/FontFace.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontFace.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace cairo.Internal
+{
+    public partial class FontFace
+    {
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_face_destroy")]
+        public static extern void Destroy(FontFaceHandle handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/FontFace.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontFace.cs
@@ -6,6 +6,6 @@ namespace cairo.Internal
     public partial class FontFace
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_face_destroy")]
-        public static extern void Destroy(FontFaceHandle handle);
+        public static extern void Destroy(FontFaceOwnedHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/FontFaceOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontFaceOwnedHandle.cs
@@ -1,0 +1,12 @@
+﻿namespace cairo.Internal
+{
+    public partial class FontFaceOwnedHandle : FontFaceHandle
+    {
+        protected override partial bool ReleaseHandle()
+        {
+            FontFace.Destroy(this);
+            return true;
+        }
+    }
+}
+

--- a/src/Libs/cairo-1.0/Internal/Records/FontOptions.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontOptions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace cairo.Internal
+{
+    public partial class FontOptions
+    {
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_options_destroy")]
+        public static extern void Destroy(FontOptionsHandle handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/FontOptions.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontOptions.cs
@@ -6,6 +6,6 @@ namespace cairo.Internal
     public partial class FontOptions
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_options_destroy")]
-        public static extern void Destroy(FontOptionsHandle handle);
+        public static extern void Destroy(FontOptionsOwnedHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/FontOptionsOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontOptionsOwnedHandle.cs
@@ -1,0 +1,12 @@
+﻿namespace cairo.Internal
+{
+    public partial class FontOptionsOwnedHandle : FontOptionsHandle
+    {
+        protected override partial bool ReleaseHandle()
+        {
+            FontOptions.Destroy(this);
+            return true;
+        }
+    }
+}
+

--- a/src/Libs/cairo-1.0/Internal/Records/MatrixOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/MatrixOwnedHandle.cs
@@ -1,0 +1,13 @@
+﻿namespace cairo.Internal
+{
+    public partial class MatrixOwnedHandle : MatrixHandle
+    {
+        protected override partial bool ReleaseHandle()
+        {
+            // There isn't any cleanup method for Cairo.Matrix. These are always
+            // allocated and owned by the caller (i.e. MatrixManagedHandle)
+            throw new System.Exception("Can't free native handle of type \"cairo.Internal.MatrixOwnedHandle\".");
+        }
+    }
+}
+

--- a/src/Libs/cairo-1.0/Internal/Records/Path.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Path.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace cairo.Internal
+{
+    public partial class Path
+    {
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_path_destroy")]
+        public static extern void Destroy(PathHandle handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/Path.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Path.cs
@@ -6,6 +6,6 @@ namespace cairo.Internal
     public partial class Path
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_path_destroy")]
-        public static extern void Destroy(PathHandle handle);
+        public static extern void Destroy(PathOwnedHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/PathOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/PathOwnedHandle.cs
@@ -1,0 +1,12 @@
+﻿namespace cairo.Internal
+{
+    public partial class PathOwnedHandle : PathHandle
+    {
+        protected override partial bool ReleaseHandle()
+        {
+            Path.Destroy(this);
+            return true;
+        }
+    }
+}
+

--- a/src/Libs/cairo-1.0/Internal/Records/Pattern.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Pattern.cs
@@ -6,6 +6,6 @@ namespace cairo.Internal
     public partial class Pattern
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_pattern_destroy")]
-        public static extern void Destroy(PatternHandle handle);
+        public static extern void Destroy(PatternOwnedHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/Pattern.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Pattern.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace cairo.Internal
+{
+    public partial class Pattern
+    {
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_pattern_destroy")]
+        public static extern void Destroy(PatternHandle handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/PatternOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/PatternOwnedHandle.cs
@@ -1,0 +1,12 @@
+﻿namespace cairo.Internal
+{
+    public partial class PatternOwnedHandle : PatternHandle
+    {
+        protected override partial bool ReleaseHandle()
+        {
+            Pattern.Destroy(this);
+            return true;
+        }
+    }
+}
+

--- a/src/Libs/cairo-1.0/Internal/Records/Region.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Region.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace cairo.Internal
+{
+    public partial class Region
+    {
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_region_destroy")]
+        public static extern void Destroy(RegionHandle handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/Region.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Region.cs
@@ -6,6 +6,6 @@ namespace cairo.Internal
     public partial class Region
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_region_destroy")]
-        public static extern void Destroy(RegionHandle handle);
+        public static extern void Destroy(RegionOwnedHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/RegionOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/RegionOwnedHandle.cs
@@ -1,0 +1,12 @@
+﻿namespace cairo.Internal
+{
+    public partial class RegionOwnedHandle : RegionHandle
+    {
+        protected override partial bool ReleaseHandle()
+        {
+            Region.Destroy(this);
+            return true;
+        }
+    }
+}
+

--- a/src/Libs/cairo-1.0/Internal/Records/ScaledFont.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ScaledFont.cs
@@ -6,6 +6,6 @@ namespace cairo.Internal
     public partial class ScaledFont
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_scaled_font_destroy")]
-        public static extern void Destroy(ScaledFontHandle handle);
+        public static extern void Destroy(ScaledFontOwnedHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/ScaledFont.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ScaledFont.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace cairo.Internal
+{
+    public partial class ScaledFont
+    {
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_scaled_font_destroy")]
+        public static extern void Destroy(ScaledFontHandle handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/ScaledFontOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ScaledFontOwnedHandle.cs
@@ -1,0 +1,12 @@
+﻿namespace cairo.Internal
+{
+    public partial class ScaledFontOwnedHandle : ScaledFontHandle
+    {
+        protected override partial bool ReleaseHandle()
+        {
+            ScaledFont.Destroy(this);
+            return true;
+        }
+    }
+}
+

--- a/src/Libs/cairo-1.0/Internal/Records/Surface.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Surface.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace cairo.Internal
+{
+    public partial class Surface
+    {
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_destroy")]
+        public static extern void Destroy(SurfaceHandle handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/Surface.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Surface.cs
@@ -6,6 +6,6 @@ namespace cairo.Internal
     public partial class Surface
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_destroy")]
-        public static extern void Destroy(SurfaceHandle handle);
+        public static extern void Destroy(SurfaceOwnedHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/SurfaceOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/SurfaceOwnedHandle.cs
@@ -1,0 +1,12 @@
+﻿namespace cairo.Internal
+{
+    public partial class SurfaceOwnedHandle : SurfaceHandle
+    {
+        protected override partial bool ReleaseHandle()
+        {
+            Surface.Destroy(this);
+            return true;
+        }
+    }
+}
+


### PR DESCRIPTION
- For foreign records, ReleaseHandle() is marked partial and not implemented, so the manual bindings are required to fill it in manually with the appropriate cleanup function
- Implement ReleaseHandle() for all of the foreign records. Added a constant for the Cairo library name in the DllImportOverride class to avoid duplicated string constants
- The one exception is Cairo.Matrix, which doesn't have a cleanup function since it's a plain C struct that is always allocated and managed by the caller, so I think only MatrixManagedHandle will ever be used.

Related to PR #578