### PR TITLE
Use PascalCase for the namespaces in generated code

### DIFF
--- a/src/Generation/Generator3/Framework.cs
+++ b/src/Generation/Generator3/Framework.cs
@@ -35,10 +35,10 @@ namespace Generator3
             if (ns.SharedLibrary is null)
                 Log.Warning($"Shared library name is not set for project {ns.GetCanonicalName()}. {ns.GetCanonicalName()} method calls will fail as the shared library won't be found.");
             else
-                internalDllImportGenerator.Generate(project, ns.SharedLibrary, ns.Name);
+                internalDllImportGenerator.Generate(project, ns);
 
-            internalExtensionsGenerator.Generate(project, ns.Name);
-            moduleDllImportGenerator.Generate(project, ns.Name);
+            internalExtensionsGenerator.Generate(project, ns);
+            moduleDllImportGenerator.Generate(project, ns);
             moduleTypeRegistration.Generate(project, ns);
         }
     }

--- a/src/Generation/Generator3/Generation/Bitfield/Model.cs
+++ b/src/Generation/Generator3/Generation/Bitfield/Model.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 using Generator3.Model.Public;
 
 namespace Generator3.Generation.Bitfield
@@ -9,7 +10,7 @@ namespace Generator3.Generation.Bitfield
         private readonly GirModel.Bitfield _bitfield;
 
         public string Name => _bitfield.Name;
-        public string NamespaceName => _bitfield.Namespace.Name;
+        public string NamespaceName => _bitfield.Namespace.GetPublicName();
         public IEnumerable<Member> Members { get; }
 
         public Model(GirModel.Bitfield bitfield)

--- a/src/Generation/Generator3/Generation/Callback/CommonHandlerModel.cs
+++ b/src/Generation/Generator3/Generation/Callback/CommonHandlerModel.cs
@@ -16,7 +16,7 @@ namespace Generator3.Generation.Callback
         public string Name { get; }
         public string DelegateType => _callback.Name;
         public string InternalDelegateType => _callback.Namespace.GetInternalName() + "." + _callback.Name;
-        public string NamespaceName => _callback.Namespace.Name;
+        public string NamespaceName => _callback.Namespace.GetPublicName();
         public Model.Internal.ReturnType InternalReturnType
             => _internalReturnType ??= _internalCallback.ReturnType;
         public IEnumerable<Parameter> InternalParameters

--- a/src/Generation/Generator3/Generation/Callback/PublicDelegate/PublicDelegateModel.cs
+++ b/src/Generation/Generator3/Generation/Callback/PublicDelegate/PublicDelegateModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 using Generator3.Model.Public;
 
 namespace Generator3.Generation.Callback
@@ -11,7 +12,7 @@ namespace Generator3.Generation.Callback
         private IEnumerable<Parameter>? _parameters;
 
         public string Name => _callback.Name;
-        public string NamespaceName => _callback.Namespace.Name;
+        public string NamespaceName => _callback.Namespace.GetPublicName();
 
         public ReturnType ReturnType => _returnType ??= _callback.ReturnType.CreatePublicModel();
         public IEnumerable<Parameter> Parameters

--- a/src/Generation/Generator3/Generation/Class/Fundamental/PublicFramework/Inheritance.cs
+++ b/src/Generation/Generator3/Generation/Class/Fundamental/PublicFramework/Inheritance.cs
@@ -1,4 +1,6 @@
-﻿namespace Generator3.Generation.Class.Fundamental
+﻿using Generator3.Converter;
+
+namespace Generator3.Generation.Class.Fundamental
 {
     public static class Inheritance
     {

--- a/src/Generation/Generator3/Generation/Class/Fundamental/PublicFramework/PublicFrameworkModel.cs
+++ b/src/Generation/Generator3/Generation/Class/Fundamental/PublicFramework/PublicFrameworkModel.cs
@@ -1,11 +1,13 @@
-﻿namespace Generator3.Generation.Class.Fundamental
+﻿using Generator3.Converter;
+
+namespace Generator3.Generation.Class.Fundamental
 {
     public class PublicFrameworkModel
     {
         private readonly GirModel.Class _class;
 
         public string Name => _class.Name;
-        public string NamespaceName => _class.Namespace.Name;
+        public string NamespaceName => _class.Namespace.GetPublicName();
         public bool HasParent => _class.Parent is not null;
 
         public GirModel.Class? ParentClass => _class.Parent;

--- a/src/Generation/Generator3/Generation/Class/Fundamental/PublicMethods/PublicMethodsModel.cs
+++ b/src/Generation/Generator3/Generation/Class/Fundamental/PublicMethods/PublicMethodsModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 using Method = Generator3.Model.Public.Method;
 
 namespace Generator3.Generation.Class.Fundamental
@@ -9,7 +10,7 @@ namespace Generator3.Generation.Class.Fundamental
         private readonly GirModel.Class _class;
 
         public string Name => _class.Name;
-        public string NamespaceName => _class.Namespace.Name;
+        public string NamespaceName => _class.Namespace.GetPublicName();
         public IEnumerable<Method> Methods { get; }
 
         public PublicMethodsModel(GirModel.Class @class)

--- a/src/Generation/Generator3/Generation/Class/Standard/PublicConstructors/PublicConstructorsModel.cs
+++ b/src/Generation/Generator3/Generation/Class/Standard/PublicConstructors/PublicConstructorsModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 using Generator3.Model.Public;
 
 namespace Generator3.Generation.Class.Standard
@@ -9,7 +10,7 @@ namespace Generator3.Generation.Class.Standard
         private readonly GirModel.Class _class;
 
         public string Name => _class.Name;
-        public string NamespaceName => _class.Namespace.Name;
+        public string NamespaceName => _class.Namespace.GetPublicName();
 
         public IEnumerable<Constructor> Constructors { get; }
 

--- a/src/Generation/Generator3/Generation/Class/Standard/PublicFramework/Inheritance.cs
+++ b/src/Generation/Generator3/Generation/Class/Standard/PublicFramework/Inheritance.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 
 namespace Generator3.Generation.Class.Standard;
 

--- a/src/Generation/Generator3/Generation/Class/Standard/PublicFramework/PublicFrameworkModel.cs
+++ b/src/Generation/Generator3/Generation/Class/Standard/PublicFramework/PublicFrameworkModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Generator3.Converter;
 
 namespace Generator3.Generation.Class.Standard
 {
@@ -7,7 +8,7 @@ namespace Generator3.Generation.Class.Standard
         private readonly GirModel.Class _class;
 
         public string Name => _class.Name;
-        public string NamespaceName => _class.Namespace.Name;
+        public string NamespaceName => _class.Namespace.GetPublicName();
         public bool HasParent => _class.Parent is not null;
         public bool InheritsInitiallyUnowned => GetInheritsInitiallyUnowned(_class);
         public bool IsInitiallyUnowned => IsNamedInitiallyUnowned(_class.Name);

--- a/src/Generation/Generator3/Generation/Class/Standard/PublicMethods/PublicMethodsModel.cs
+++ b/src/Generation/Generator3/Generation/Class/Standard/PublicMethods/PublicMethodsModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 using Generator3.Model.Public;
 
 namespace Generator3.Generation.Class.Standard
@@ -9,7 +10,7 @@ namespace Generator3.Generation.Class.Standard
         private readonly GirModel.Class _class;
 
         public string Name => _class.Name;
-        public string NamespaceName => _class.Namespace.Name;
+        public string NamespaceName => _class.Namespace.GetPublicName();
 
         public IEnumerable<Method> Methods { get; }
 

--- a/src/Generation/Generator3/Generation/Class/Standard/PublicProperties/PublicPropertiesModel.cs
+++ b/src/Generation/Generator3/Generation/Class/Standard/PublicProperties/PublicPropertiesModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 using Generator3.Model.Public;
 
 namespace Generator3.Generation.Class.Standard
@@ -9,7 +10,7 @@ namespace Generator3.Generation.Class.Standard
         private readonly GirModel.Class _class;
 
         public string Name => _class.Name;
-        public string NamespaceName => _class.Namespace.Name;
+        public string NamespaceName => _class.Namespace.GetPublicName();
 
         public IEnumerable<Property> Properties { get; }
 

--- a/src/Generation/Generator3/Generation/Class/Standard/PublicSignals/PublicSignalsModel.cs
+++ b/src/Generation/Generator3/Generation/Class/Standard/PublicSignals/PublicSignalsModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 using Generator3.Model.Public;
 
 namespace Generator3.Generation.Class.Standard
@@ -9,7 +10,7 @@ namespace Generator3.Generation.Class.Standard
         private readonly GirModel.Class _class;
 
         public string Name => _class.Name;
-        public string NamespaceName => _class.Namespace.Name;
+        public string NamespaceName => _class.Namespace.GetPublicName();
         public IEnumerable<Signal> Signals { get; }
 
         public PublicSignalsModel(GirModel.Class @class)

--- a/src/Generation/Generator3/Generation/Constants/Model.cs
+++ b/src/Generation/Generator3/Generation/Constants/Model.cs
@@ -9,7 +9,7 @@ namespace Generator3.Generation.Constants
     {
         private readonly IEnumerable<GirModel.Constant> _constants;
 
-        public string NamespaceName => _constants.First().Namespace.Name;
+        public string NamespaceName => _constants.First().Namespace.GetPublicName();
         public IEnumerable<Constant> Constants { get; }
 
         public Model(IEnumerable<GirModel.Constant> constants)

--- a/src/Generation/Generator3/Generation/Enumeration/Model.cs
+++ b/src/Generation/Generator3/Generation/Enumeration/Model.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 using Generator3.Model.Public;
 
 namespace Generator3.Generation.Enumeration
@@ -9,7 +10,7 @@ namespace Generator3.Generation.Enumeration
         private readonly GirModel.Enumeration _enumeration;
 
         public string Name => _enumeration.Name;
-        public string NamespaceName => _enumeration.Namespace.Name;
+        public string NamespaceName => _enumeration.Namespace.GetPublicName();
         public IEnumerable<Member> Members { get; }
 
         public Model(GirModel.Enumeration enumeration)

--- a/src/Generation/Generator3/Generation/Framework/InternalDllImport/InternalDllImportGenerator.cs
+++ b/src/Generation/Generator3/Generation/Framework/InternalDllImport/InternalDllImportGenerator.cs
@@ -11,11 +11,11 @@
             _publisher = publisher;
         }
 
-        public void Generate(string project, string sharedLibrary, string @namespace)
+        public void Generate(string project, GirModel.Namespace ns)
         {
             try
             {
-                var model = new InternalDllImportModel(sharedLibrary, @namespace);
+                var model = new InternalDllImportModel(ns);
                 var source = _template.Render(model);
                 var codeUnit = new CodeUnit(project, "DllImport", source);
                 _publisher.Publish(codeUnit);

--- a/src/Generation/Generator3/Generation/Framework/InternalDllImport/InternalDllImportModel.cs
+++ b/src/Generation/Generator3/Generation/Framework/InternalDllImport/InternalDllImportModel.cs
@@ -1,20 +1,23 @@
-﻿namespace Generator3.Generation.Framework
+﻿using Generator3.Converter;
+
+namespace Generator3.Generation.Framework
 {
     public class InternalDllImportModel
     {
-        public string NamespaceName { get; }
-        public string LibraryName { get; }
+        private readonly GirModel.Namespace _ns;
+
+        public string NamespaceName => _ns.GetInternalName();
+        public string LibraryName => _ns.Name;
 
         public string WindowsDll { get; }
         public string LinuxDll { get; }
         public string OsxDll { get; }
 
-        public InternalDllImportModel(string sharedLibrary, string @namespace)
+        public InternalDllImportModel(GirModel.Namespace ns)
         {
-            this.LibraryName = @namespace;
-            this.NamespaceName = @namespace + ".Internal";
+            _ns = ns;
 
-            var dllImportResolver = new DllImportResolver(sharedLibrary, @namespace);
+            var dllImportResolver = new DllImportResolver(ns.SharedLibrary, ns.Name);
 
             WindowsDll = dllImportResolver.GetWindowsDllImport();
             LinuxDll = dllImportResolver.GetLinuxDllImport();

--- a/src/Generation/Generator3/Generation/Framework/InternalExtensions/InternalExtensionsGenerator.cs
+++ b/src/Generation/Generator3/Generation/Framework/InternalExtensions/InternalExtensionsGenerator.cs
@@ -11,11 +11,11 @@
             _publisher = publisher;
         }
 
-        public void Generate(string project, string @namespace)
+        public void Generate(string project, GirModel.Namespace ns)
         {
             try
             {
-                var model = new InternalExtensionsModel(@namespace);
+                var model = new InternalExtensionsModel(ns);
                 var source = _template.Render(model);
                 var codeUnit = new CodeUnit(project, "Extensions", source);
                 _publisher.Publish(codeUnit);

--- a/src/Generation/Generator3/Generation/Framework/InternalExtensions/InternalExtensionsModel.cs
+++ b/src/Generation/Generator3/Generation/Framework/InternalExtensions/InternalExtensionsModel.cs
@@ -1,14 +1,16 @@
-﻿namespace Generator3.Generation.Framework
+﻿using Generator3.Converter;
+
+namespace Generator3.Generation.Framework
 {
     public class InternalExtensionsModel
     {
-        private readonly string _namespace;
+        private readonly GirModel.Namespace _ns;
 
-        public string NamespaceName => _namespace + ".Internal";
+        public string NamespaceName => _ns.GetInternalName();
 
-        public InternalExtensionsModel(string @namespace)
+        public InternalExtensionsModel(GirModel.Namespace ns)
         {
-            this._namespace = @namespace;
+            _ns = ns;
         }
     }
 }

--- a/src/Generation/Generator3/Generation/Framework/PublicModuleDllImport/ModuleDllImportGenerator.cs
+++ b/src/Generation/Generator3/Generation/Framework/PublicModuleDllImport/ModuleDllImportGenerator.cs
@@ -11,11 +11,11 @@
             _publisher = publisher;
         }
 
-        public void Generate(string project, string @namespace)
+        public void Generate(string project, GirModel.Namespace ns)
         {
             try
             {
-                var model = new ModuleDllImportModel(@namespace);
+                var model = new ModuleDllImportModel(ns);
                 var source = _template.Render(model);
                 var codeUnit = new CodeUnit(project, "Module.DllImport", source);
                 _publisher.Publish(codeUnit);

--- a/src/Generation/Generator3/Generation/Framework/PublicModuleDllImport/ModuleDllImportModel.cs
+++ b/src/Generation/Generator3/Generation/Framework/PublicModuleDllImport/ModuleDllImportModel.cs
@@ -1,12 +1,16 @@
-﻿namespace Generator3.Generation.Framework
+﻿using Generator3.Converter;
+
+namespace Generator3.Generation.Framework
 {
     public class ModuleDllImportModel
     {
-        public string NamespaceName { get; }
+        private readonly GirModel.Namespace _ns;
 
-        public ModuleDllImportModel(string @namespace)
+        public string NamespaceName => _ns.GetPublicName();
+
+        public ModuleDllImportModel(GirModel.Namespace ns)
         {
-            this.NamespaceName = @namespace;
+            _ns = ns;
         }
     }
 }

--- a/src/Generation/Generator3/Generation/Framework/PublicModuleTypeRegistration/PublicModuleTypeRegistrationModel.cs
+++ b/src/Generation/Generator3/Generation/Framework/PublicModuleTypeRegistration/PublicModuleTypeRegistrationModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Generator3.Converter;
 
 namespace Generator3.Generation.Framework
 {
@@ -7,7 +8,7 @@ namespace Generator3.Generation.Framework
     {
         private readonly GirModel.Namespace _ns;
 
-        public string NamespaceName => _ns.Name;
+        public string NamespaceName => _ns.GetPublicName();
 
         public IEnumerable<GirModel.Class> Classes => _ns.Classes.Where(cls => !cls.IsFundamental);
         public IEnumerable<GirModel.Record> Records => _ns.Records.Where(record => record.TypeFunction is not null);

--- a/src/Generation/Generator3/Generation/Interface/PublicFramework/PublicFrameworkModel.cs
+++ b/src/Generation/Generator3/Generation/Interface/PublicFramework/PublicFrameworkModel.cs
@@ -1,11 +1,13 @@
-﻿namespace Generator3.Generation.Interface
+﻿using Generator3.Converter;
+
+namespace Generator3.Generation.Interface
 {
     public class PublicFrameworkModel
     {
         private readonly GirModel.Interface _interface;
 
         public string Name => _interface.Name;
-        public string NamespaceName => _interface.Namespace.Name;
+        public string NamespaceName => _interface.Namespace.GetPublicName();
 
         public PublicFrameworkModel(GirModel.Interface @interface)
         {

--- a/src/Generation/Generator3/Generation/Interface/PublicMethods/PublicMethodsModel.cs
+++ b/src/Generation/Generator3/Generation/Interface/PublicMethods/PublicMethodsModel.cs
@@ -1,11 +1,13 @@
-﻿namespace Generator3.Generation.Interface
+﻿using Generator3.Converter;
+
+namespace Generator3.Generation.Interface
 {
     public class PublicMethodsModel
     {
         private readonly GirModel.Interface _interface;
 
         public string Name => _interface.Name;
-        public string NamespaceName => _interface.Namespace.Name;
+        public string NamespaceName => _interface.Namespace.GetPublicName();
 
         public PublicMethodsModel(GirModel.Interface @interface)
         {

--- a/src/Generation/Generator3/Generation/Record/InternalHandle/InternalHandleModel.cs
+++ b/src/Generation/Generator3/Generation/Record/InternalHandle/InternalHandleModel.cs
@@ -10,7 +10,6 @@ namespace Generator3.Generation.Record
         public string NullHandleName => Record.GetInternalNullHandleName();
         public string UnownedHandleName => Record.GetInternalUnownedHandleName();
         public string InternalNamespaceName => Record.Namespace.GetInternalName();
-        public string NamespaceName => Record.Namespace.Name;
         public GirModel.Record Record { get; }
 
         public InternalHandleModel(GirModel.Record record)

--- a/src/Generation/Generator3/Generation/Record/PublicClass/PublicClassModel.cs
+++ b/src/Generation/Generator3/Generation/Record/PublicClass/PublicClassModel.cs
@@ -10,7 +10,7 @@ namespace Generator3.Generation.Record
         public string InternalHandleName => _record.GetInternalHandleName();
         public string InternalOwnedHandleName => _record.GetInternalOwnedHandleName();
         public string InternalUnownedHandleName => _record.GetInternalUnownedHandleName();
-        public string NamespaceName => _record.Namespace.Name;
+        public string NamespaceName => _record.Namespace.GetPublicName();
 
         public PublicClassModel(GirModel.Record record)
         {

--- a/src/Generation/Generator3/Model/Internal/ReturnType/BitfieldReturnType.cs
+++ b/src/Generation/Generator3/Model/Internal/ReturnType/BitfieldReturnType.cs
@@ -1,4 +1,6 @@
-﻿namespace Generator3.Model.Internal
+﻿using Generator3.Converter;
+
+namespace Generator3.Model.Internal
 {
     public class BitfieldReturnType : ReturnType
     {

--- a/src/Generation/Generator3/Model/Internal/ReturnType/EnumerationReturnType.cs
+++ b/src/Generation/Generator3/Model/Internal/ReturnType/EnumerationReturnType.cs
@@ -1,4 +1,6 @@
-﻿namespace Generator3.Model.Internal
+﻿using Generator3.Converter;
+
+namespace Generator3.Model.Internal
 {
     public class EnumerationReturnType : ReturnType
     {

--- a/src/Generation/Generator3/Model/Public/InstanceParameter/ClassInstanceParameter.cs
+++ b/src/Generation/Generator3/Model/Public/InstanceParameter/ClassInstanceParameter.cs
@@ -1,4 +1,6 @@
-﻿namespace Generator3.Model.Public
+﻿using Generator3.Converter;
+
+namespace Generator3.Model.Public
 {
     public class ClassInstanceParameter : InstanceParameter
     {

--- a/src/Generation/Generator3/Model/Public/ReturnType/BitfieldReturnType.cs
+++ b/src/Generation/Generator3/Model/Public/ReturnType/BitfieldReturnType.cs
@@ -1,4 +1,6 @@
-﻿namespace Generator3.Model.Public
+﻿using Generator3.Converter;
+
+namespace Generator3.Model.Public
 {
     public class BitfieldReturnType : ReturnType
     {

--- a/src/Generation/Generator3/Model/Public/ReturnType/ClassReturnType.cs
+++ b/src/Generation/Generator3/Model/Public/ReturnType/ClassReturnType.cs
@@ -1,4 +1,6 @@
-﻿namespace Generator3.Model.Public
+﻿using Generator3.Converter;
+
+namespace Generator3.Model.Public
 {
     public class ClassReturnType : ReturnType
     {

--- a/src/Generation/Generator3/Model/Public/ReturnType/EnumerationReturnType.cs
+++ b/src/Generation/Generator3/Model/Public/ReturnType/EnumerationReturnType.cs
@@ -1,4 +1,6 @@
-﻿namespace Generator3.Model.Public
+﻿using Generator3.Converter;
+
+namespace Generator3.Model.Public
 {
     public class EnumerationReturnType : ReturnType
     {

--- a/src/Generation/Generator3/Model/Public/ReturnType/InterfaceReturnType.cs
+++ b/src/Generation/Generator3/Model/Public/ReturnType/InterfaceReturnType.cs
@@ -1,4 +1,6 @@
-﻿namespace Generator3.Model.Public
+﻿using Generator3.Converter;
+
+namespace Generator3.Model.Public
 {
     public class InterfaceReturnType : ReturnType
     {

--- a/src/Generation/Generator3/Model/Public/ReturnType/RecordReturnType.cs
+++ b/src/Generation/Generator3/Model/Public/ReturnType/RecordReturnType.cs
@@ -1,4 +1,6 @@
-﻿namespace Generator3.Model.Public
+﻿using Generator3.Converter;
+
+namespace Generator3.Model.Public
 {
     public class RecordReturnType : ReturnType
     {

--- a/src/Generation/Generator3/ModelExtension/ComplexTypeExtension.cs
+++ b/src/Generation/Generator3/ModelExtension/ComplexTypeExtension.cs
@@ -1,0 +1,8 @@
+﻿namespace Generator3.Converter
+{
+    public static class ComplexTypeExtension
+    {
+        public static string GetFullyQualified(this GirModel.ComplexType type)
+            => type.Namespace.GetPublicName() + "." + type.Name;
+    }
+}

--- a/src/Generation/Generator3/ModelExtension/NamespaceNameExtension.cs
+++ b/src/Generation/Generator3/ModelExtension/NamespaceNameExtension.cs
@@ -2,10 +2,13 @@
 {
     public static class NamespaceNameExtension
     {
+        public static string GetPublicName(this GirModel.Namespace @namespace)
+            => @namespace.Name.ToPascalCase().EscapeIdentifier();
+
         public static string GetCanonicalName(this GirModel.Namespace @namespace)
             => $"{@namespace.Name}-{@namespace.Version}";
 
         public static string GetInternalName(this GirModel.Namespace @namespace)
-            => $"{@namespace.Name}.Internal";
+            => $"{@namespace.GetPublicName()}.Internal";
     }
 }

--- a/src/Generation/Generator3/ModelExtension/RecordNameExtension.cs
+++ b/src/Generation/Generator3/ModelExtension/RecordNameExtension.cs
@@ -21,7 +21,7 @@
             => record.Namespace.GetInternalName() + "." + GetInternalManagedHandleName(record) + ".Create";
 
         public static string GetFullyQualifiedPublicClassName(this GirModel.Record record)
-            => record.Namespace.Name + "." + record.GetPublicClassName();
+            => record.Namespace.GetPublicName() + "." + record.GetPublicClassName();
 
         public static string GetPublicClassName(this GirModel.Record record)
             => record.Name;

--- a/src/Generation/GirModel/ComplexType.cs
+++ b/src/Generation/GirModel/ComplexType.cs
@@ -4,7 +4,5 @@
     {
         public Namespace Namespace { get; }
         public string Name { get; }
-
-        public string GetFullyQualified() => Namespace.Name + "." + Name;
     }
 }

--- a/src/Libs/cairo-1.0/Framework/Module.cs
+++ b/src/Libs/cairo-1.0/Framework/Module.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
-namespace cairo
+namespace Cairo
 {
     internal partial class Module
     {

--- a/src/Libs/cairo-1.0/Internal/Framework/DllImportOverride.cs
+++ b/src/Libs/cairo-1.0/Internal/Framework/DllImportOverride.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 #nullable enable
 
-namespace cairo.Internal
+namespace Cairo.Internal
 {
     // Manual override of the DllImport class so we can handle
     // cairo being in multiple shared libraries/dlls. See the

--- a/src/Libs/cairo-1.0/Internal/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace cairo.Internal
+namespace Cairo.Internal
 {
     public partial class Context
     {

--- a/src/Libs/cairo-1.0/Internal/Records/ContextOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ContextOwnedHandle.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo.Internal
+﻿namespace Cairo.Internal
 {
     public partial class ContextOwnedHandle : ContextHandle
     {

--- a/src/Libs/cairo-1.0/Internal/Records/Device.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Device.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace cairo.Internal
+namespace Cairo.Internal
 {
     public partial class Device
     {

--- a/src/Libs/cairo-1.0/Internal/Records/DeviceOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/DeviceOwnedHandle.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo.Internal
+﻿namespace Cairo.Internal
 {
     public partial class DeviceOwnedHandle : DeviceHandle
     {

--- a/src/Libs/cairo-1.0/Internal/Records/FontFace.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontFace.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace cairo.Internal
+namespace Cairo.Internal
 {
     public partial class FontFace
     {

--- a/src/Libs/cairo-1.0/Internal/Records/FontFaceOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontFaceOwnedHandle.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo.Internal
+﻿namespace Cairo.Internal
 {
     public partial class FontFaceOwnedHandle : FontFaceHandle
     {

--- a/src/Libs/cairo-1.0/Internal/Records/FontOptions.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontOptions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace cairo.Internal
+namespace Cairo.Internal
 {
     public partial class FontOptions
     {

--- a/src/Libs/cairo-1.0/Internal/Records/FontOptionsOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontOptionsOwnedHandle.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo.Internal
+﻿namespace Cairo.Internal
 {
     public partial class FontOptionsOwnedHandle : FontOptionsHandle
     {

--- a/src/Libs/cairo-1.0/Internal/Records/MatrixOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/MatrixOwnedHandle.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo.Internal
+﻿namespace Cairo.Internal
 {
     public partial class MatrixOwnedHandle : MatrixHandle
     {

--- a/src/Libs/cairo-1.0/Internal/Records/Path.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Path.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace cairo.Internal
+namespace Cairo.Internal
 {
     public partial class Path
     {

--- a/src/Libs/cairo-1.0/Internal/Records/PathOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/PathOwnedHandle.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo.Internal
+﻿namespace Cairo.Internal
 {
     public partial class PathOwnedHandle : PathHandle
     {

--- a/src/Libs/cairo-1.0/Internal/Records/Pattern.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Pattern.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace cairo.Internal
+namespace Cairo.Internal
 {
     public partial class Pattern
     {

--- a/src/Libs/cairo-1.0/Internal/Records/PatternOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/PatternOwnedHandle.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo.Internal
+﻿namespace Cairo.Internal
 {
     public partial class PatternOwnedHandle : PatternHandle
     {

--- a/src/Libs/cairo-1.0/Internal/Records/Region.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Region.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace cairo.Internal
+namespace Cairo.Internal
 {
     public partial class Region
     {

--- a/src/Libs/cairo-1.0/Internal/Records/RegionOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/RegionOwnedHandle.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo.Internal
+﻿namespace Cairo.Internal
 {
     public partial class RegionOwnedHandle : RegionHandle
     {

--- a/src/Libs/cairo-1.0/Internal/Records/ScaledFont.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ScaledFont.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace cairo.Internal
+namespace Cairo.Internal
 {
     public partial class ScaledFont
     {

--- a/src/Libs/cairo-1.0/Internal/Records/ScaledFontOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ScaledFontOwnedHandle.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo.Internal
+﻿namespace Cairo.Internal
 {
     public partial class ScaledFontOwnedHandle : ScaledFontHandle
     {

--- a/src/Libs/cairo-1.0/Internal/Records/Surface.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Surface.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
-namespace cairo.Internal
+namespace Cairo.Internal
 {
     public partial class Surface
     {

--- a/src/Libs/cairo-1.0/Internal/Records/SurfaceOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/SurfaceOwnedHandle.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo.Internal
+﻿namespace Cairo.Internal
 {
     public partial class SurfaceOwnedHandle : SurfaceHandle
     {

--- a/src/Libs/cairo-1.0/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Records/Context.cs
@@ -1,4 +1,4 @@
-﻿namespace cairo
+﻿namespace Cairo
 {
     public partial class Context
     {

--- a/src/Libs/cairo-1.0/Records/FontExtents.cs
+++ b/src/Libs/cairo-1.0/Records/FontExtents.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace cairo
+namespace Cairo
 {
     [StructLayout(LayoutKind.Sequential)]
     public struct FontExtents

--- a/src/Libs/cairo-1.0/Records/TextExtents.cs
+++ b/src/Libs/cairo-1.0/Records/TextExtents.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace cairo
+namespace Cairo
 {
     [StructLayout(LayoutKind.Sequential)]
     public struct TextExtents

--- a/src/Samples/Gtk3/DrawingArea/DrawingArea.cs
+++ b/src/Samples/Gtk3/DrawingArea/DrawingArea.cs
@@ -8,7 +8,7 @@ window.Child = drawingArea;
 
 drawingArea.OnDraw += (d, a) =>
 {
-    cairo.Context cr = a.Cr;
+    Cairo.Context cr = a.Cr;
     cr.SetSourceRgba(0.1, 0.1, 0.1, 1.0);
     cr.MoveTo(20, 30);
     cr.ShowText("This is some text, drawn with cairo");

--- a/src/Samples/Gtk3/TextEditor/Application/DocumentView.cs
+++ b/src/Samples/Gtk3/TextEditor/Application/DocumentView.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Text;
-using cairo;
+using Cairo;
 using Gdk;
 using Gtk;
 using Pango;
@@ -130,7 +130,7 @@ namespace TextEditor.Application
             int xDist = 30;
             int yDist = 100;
 
-            cairo.Context cr = e.Cr;
+            Cairo.Context cr = e.Cr;
 
             // Fill background
             cr.SetSourceRgba(1, 1, 1, 1);

--- a/src/Samples/Gtk3/TextEditor/Application/PieceTableDisplay.cs
+++ b/src/Samples/Gtk3/TextEditor/Application/PieceTableDisplay.cs
@@ -1,4 +1,4 @@
-﻿using cairo;
+﻿using Cairo;
 using Gtk;
 
 namespace TextEditor.Application


### PR DESCRIPTION
- Update models to use the new extension method for the public namespace name
- Fix a couple places that didn't pass the `GirModel.Namespace` into the model, e.g. `InternalExtensionsModel`, which also had duplicate logic for determining the internal namespace name
- Move `ComplexType.GetFullyQualified()` into the Generator3 library, so it can use the namespace extension methods. There weren't any uses of this in the GirModel library
- Update manual code for the new `Cairo` namespace name

A couple usages are left as-is for now, but could be updated too:
- `GetCanonicalName()`, which I think would change the file paths to e.g. `Cairo-1.0` from `cairo-1.0`.
- The names used for `DllImport` are also left as-is

#577