### PR TITLE
Add most of the Cairo.Surface bindings

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Records/FontOptions.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontOptions.cs
@@ -5,7 +5,13 @@ namespace Cairo.Internal
 {
     public partial class FontOptions
     {
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_options_create")]
+        public static extern FontOptionsOwnedHandle Create();
+
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_options_destroy")]
         public static extern void Destroy(FontOptionsOwnedHandle handle);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_options_status")]
+        public static extern Status Status(FontOptionsHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/Surface.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Surface.cs
@@ -6,5 +6,59 @@ namespace Cairo.Internal
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_destroy")]
         public static extern void Destroy(SurfaceOwnedHandle handle);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_create_similar")]
+        public static extern SurfaceOwnedHandle CreateSimilar(SurfaceHandle handle, Content content, int width, int height);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_create_similar_image")]
+        public static extern SurfaceOwnedHandle CreateSimilarImage(SurfaceHandle handle, Format format, int width, int height);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_create_for_rectangle")]
+        public static extern SurfaceOwnedHandle CreateForRectangle(SurfaceHandle handle, double x, double y, double width, double height);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_get_content")]
+        public static extern Content GetContent(SurfaceHandle handle);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_get_device")]
+        public static extern DeviceUnownedHandle GetDevice(SurfaceHandle handle);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_get_device_offset")]
+        public static extern void GetDeviceOffset(SurfaceHandle handle, out double xOffset, out double yOffset);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_get_device_scale")]
+        public static extern void GetDeviceScale(SurfaceHandle handle, out double xScale, out double yScale);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_get_fallback_resolution")]
+        public static extern void GetFallbackResolution(SurfaceHandle handle, out double xPixelsPerInch, out double yPixelsPerInch);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_get_font_options")]
+        public static extern void GetFontOptions(SurfaceHandle handle, FontOptionsHandle options);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_get_type")]
+        public static extern SurfaceType GetType(SurfaceHandle handle);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_finish")]
+        public static extern void Finish(SurfaceHandle handle);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_flush")]
+        public static extern void Flush(SurfaceHandle handle);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_mark_dirty")]
+        public static extern void MarkDirty(SurfaceHandle handle);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_mark_dirty_rectangle")]
+        public static extern void MarkDirtyRectangle(SurfaceHandle handle, int x, int y, int width, int height);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_set_device_offset")]
+        public static extern void SetDeviceOffset(SurfaceHandle handle, double xOffset, double yOffset);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_set_device_scale")]
+        public static extern void SetDeviceScale(SurfaceHandle handle, double xScale, double yScale);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_set_fallback_resolution")]
+        public static extern void SetFallbackResolution(SurfaceHandle handle, double xPixelsPerInch, double yPixelsPerInch);
+
+        [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_status")]
+        public static extern Status Status(SurfaceHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Records/FontOptions.cs
+++ b/src/Libs/cairo-1.0/Records/FontOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace Cairo
+{
+    public partial class FontOptions
+    {
+        public FontOptions()
+            : this(Internal.FontOptions.Create())
+        {
+        }
+
+        public Status Status => Internal.FontOptions.Status(Handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Records/Surface.cs
+++ b/src/Libs/cairo-1.0/Records/Surface.cs
@@ -1,0 +1,64 @@
+﻿namespace Cairo
+{
+    public partial class Surface
+    {
+        // Cached to avoid creating new references for each property access.
+        private Device? _device;
+
+        public Content Content => Internal.Surface.GetContent(Handle);
+        public Device Device => _device ??= new Device(Internal.Surface.GetDevice(Handle));
+        public Status Status => Internal.Surface.Status(Handle);
+        public SurfaceType SurfaceType => Internal.Surface.GetType(Handle);
+
+        public (double X, double Y) DeviceOffset
+        {
+            get
+            {
+                Internal.Surface.GetDeviceOffset(Handle, out double xOffset, out double yOffset);
+                return (xOffset, yOffset);
+            }
+            set => Internal.Surface.SetDeviceOffset(Handle, value.X, value.Y);
+        }
+
+        public (double X, double Y) DeviceScale
+        {
+            get
+            {
+                Internal.Surface.GetDeviceScale(Handle, out double xScale, out double yScale);
+                return (xScale, yScale);
+            }
+            set => Internal.Surface.SetDeviceScale(Handle, value.X, value.Y);
+        }
+
+        public (double X, double Y) FallbackResolution
+        {
+            get
+            {
+                Internal.Surface.GetFallbackResolution(Handle, out double xPixelsPerInch, out double yPixelsPerInch);
+                return (xPixelsPerInch, yPixelsPerInch);
+            }
+            set => Internal.Surface.SetFallbackResolution(Handle, value.X, value.Y);
+        }
+
+        public void GetFontOptions(FontOptions options)
+            => Internal.Surface.GetFontOptions(Handle, options.Handle);
+
+        public Surface CreateSimilar(Content content, int width, int height)
+            => new Surface(Internal.Surface.CreateSimilar(Handle, content, width, height));
+
+        public Surface CreateSimilarImage(Format format, int width, int height)
+            => new Surface(Internal.Surface.CreateSimilarImage(Handle, format, width, height));
+
+        public Surface CreateForRectangle(double x, double y, double width, double height)
+            => new Surface(Internal.Surface.CreateForRectangle(Handle, x, y, width, height));
+
+        public void Finish() => Internal.Surface.Finish(Handle);
+
+        public void Flush() => Internal.Surface.Flush(Handle);
+
+        public void MarkDirty() => Internal.Surface.MarkDirty(Handle);
+
+        public void MarkDirty(int x, int y, int width, int height)
+            => Internal.Surface.MarkDirtyRectangle(Handle, x, y, width, height);
+    }
+}

--- a/src/Tests/Libs/Cairo-1.0.Tests/FontOptionsTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/FontOptionsTest.cs
@@ -1,0 +1,16 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Cairo.Tests
+{
+    [TestClass, TestCategory("IntegrationTest")]
+    public class FontOptionsTest
+    {
+        [TestMethod]
+        public void BindingsShouldSucceed()
+        {
+            var opts = new FontOptions();
+            opts.Status.Should().Be(Status.Success);
+        }
+    }
+}

--- a/src/Tests/Libs/Cairo-1.0.Tests/ImageSurfaceTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/ImageSurfaceTest.cs
@@ -7,13 +7,47 @@ namespace Cairo.Tests
     public class ImageSurfaceTest
     {
         [TestMethod]
-        public void ImageSurfaceConstructorShouldSucceed()
+        public void BindingsShouldSucceed()
         {
             var surf = new Cairo.ImageSurface(Cairo.Format.Argb32, 800, 600);
+            surf.Status.Should().Be(Status.Success);
+
             surf.Width.Should().Be(800);
             surf.Height.Should().Be(600);
             surf.Format.Should().Be(Cairo.Format.Argb32);
             surf.Stride.Should().Be(3200);
+
+            surf.CreateSimilar(Content.Alpha, 400, 300).Status.Should().Be(Status.Success);
+            surf.CreateSimilarImage(Format.Argb32, 400, 300).Status.Should().Be(Status.Success);
+            surf.CreateForRectangle(0, 0, 400, 300).Status.Should().Be(Status.Success);
+
+            var res = (4, 5);
+            surf.FallbackResolution = res;
+            surf.FallbackResolution.Should().Be(res);
+
+            var offset = (2, 3);
+            surf.DeviceOffset = offset;
+            surf.DeviceOffset.Should().Be(offset);
+
+            var scale = (1.2, 2.3);
+            surf.DeviceScale = scale;
+            surf.DeviceScale.Should().Be(scale);
+
+            surf.Content.Should().Be(Content.ColorAlpha);
+            surf.SurfaceType.Should().Be(SurfaceType.Image);
+            // Just verify this succeeds, until Cairo.Device has more methods
+            surf.Device.Should().NotBeNull();
+
+            var opts = new FontOptions();
+            surf.GetFontOptions(opts);
+            opts.Status.Should().Be(Status.Success);
+
+            surf.Flush();
+            surf.MarkDirty();
+            surf.MarkDirty(1, 2, 3, 4);
+
+            surf.Finish();
+            surf.Status.Should().Be(Status.Success);
         }
     }
 }


### PR DESCRIPTION
- Add bindings for the majority of Cairo.Surface functions. A couple such as 'cairo_surface_set_mime_data' and 'cairo_surface_set_user_data' are skipped, which have more complex lifetime requirements
- Add minimal bindings for FontOptions in order to be able to implement cairo_surface_get_font_options()