### PR TITLE
Wait for garbage collector to free memory

### DIFF
--- a/src/Tests/Libs/Cairo-1.0.Tests/FontOptionsTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/FontOptionsTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Cairo.Tests
 {
     [TestClass, TestCategory("IntegrationTest")]
-    public class FontOptionsTest
+    public class FontOptionsTest : Test
     {
         [TestMethod]
         public void BindingsShouldSucceed()

--- a/src/Tests/Libs/Cairo-1.0.Tests/ImageSurfaceTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/ImageSurfaceTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Cairo.Tests
 {
     [TestClass, TestCategory("IntegrationTest")]
-    public class ImageSurfaceTest
+    public class ImageSurfaceTest : Test
     {
         [TestMethod]
         public void BindingsShouldSucceed()

--- a/src/Tests/Libs/Cairo-1.0.Tests/Test.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/Test.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Cairo.Tests;
+
+public abstract class Test
+{
+    [TestCleanup]
+    public void Cleanup()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+    }
+}

--- a/src/Tests/Libs/GLib-2.0.Tests/Records/ExceptionTest.cs
+++ b/src/Tests/Libs/GLib-2.0.Tests/Records/ExceptionTest.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GLib.Tests
 {
     [TestClass, TestCategory("IntegrationTest")]
-    public class ExceptionTest
+    public class ExceptionTest : Test
     {
         [TestMethod]
         public void ErrorsRaiseAnException()

--- a/src/Tests/Libs/GLib-2.0.Tests/Records/UnownedHandleTest.cs
+++ b/src/Tests/Libs/GLib-2.0.Tests/Records/UnownedHandleTest.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GLib.Tests
 {
     [TestClass, TestCategory("IntegrationTest")]
-    public class MemoryManagementTest
+    public class MemoryManagementTest : Test
     {
         [TestMethod]
         public void UnownedHandleIsNotFreed()

--- a/src/Tests/Libs/GLib-2.0.Tests/Records/VariantTest.cs
+++ b/src/Tests/Libs/GLib-2.0.Tests/Records/VariantTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GLib.Tests
 {
     [TestClass, TestCategory("IntegrationTest")]
-    public class VariantTest
+    public class VariantTest : Test
     {
         [TestMethod]
         public void CanCreateInt()

--- a/src/Tests/Libs/GLib-2.0.Tests/Records/VariantTypeTest.cs
+++ b/src/Tests/Libs/GLib-2.0.Tests/Records/VariantTypeTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GLib.Tests
 {
     [TestClass, TestCategory("IntegrationTest")]
-    public class VariantTypeTest
+    public class VariantTypeTest : Test
     {
         [DataTestMethod]
         [DataRow("s")]

--- a/src/Tests/Libs/GLib-2.0.Tests/Test.cs
+++ b/src/Tests/Libs/GLib-2.0.Tests/Test.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GLib.Tests;
+
+public abstract class Test
+{
+    [TestCleanup]
+    public void Cleanup()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+    }
+}

--- a/src/Tests/Libs/GObject-2.0.Tests/Classes/ParamSpecTest.cs
+++ b/src/Tests/Libs/GObject-2.0.Tests/Classes/ParamSpecTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GObject.Tests.Classes
 {
     [TestClass, TestCategory("IntegrationTest")]
-    public class ParamSpecTest
+    public class ParamSpecTest : Test
     {
         [TestMethod]
         public void CanCreateBooleanParamSpec()

--- a/src/Tests/Libs/GObject-2.0.Tests/Records/ValueTest.cs
+++ b/src/Tests/Libs/GObject-2.0.Tests/Records/ValueTest.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GObject.Tests
 {
     [TestClass, TestCategory("IntegrationTest")]
-    public class ValueTest
+    public class ValueTest : Test
     {
         [DataTestMethod]
         [DataRow(5)]

--- a/src/Tests/Libs/GObject-2.0.Tests/Test.cs
+++ b/src/Tests/Libs/GObject-2.0.Tests/Test.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GObject.Tests;
+
+public abstract class Test
+{
+    [TestCleanup]
+    public void Cleanup()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+    }
+}

--- a/src/Tests/Libs/GdkPixbuf-2.0.Tests/MemoryManagementTest.cs
+++ b/src/Tests/Libs/GdkPixbuf-2.0.Tests/MemoryManagementTest.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GdkPixbuf.Tests
 {
     [TestClass, TestCategory("IntegrationTest")]
-    public class MemoryManagementTest
+    public class MemoryManagementTest : Test
     {
         [TestMethod]
         public void TestAutomaticGObjectDisposal()

--- a/src/Tests/Libs/GdkPixbuf-2.0.Tests/PropertyTest.cs
+++ b/src/Tests/Libs/GdkPixbuf-2.0.Tests/PropertyTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GdkPixbuf.Tests;
 
 [TestClass, TestCategory("IntegrationTest")]
-public class PropertyTest
+public class PropertyTest : Test
 {
     [TestMethod]
     public void TestIntegerProperty()

--- a/src/Tests/Libs/GdkPixbuf-2.0.Tests/Test.cs
+++ b/src/Tests/Libs/GdkPixbuf-2.0.Tests/Test.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GdkPixbuf.Tests;
+
+public abstract class Test
+{
+    [TestCleanup]
+    public void Cleanup()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+    }
+}

--- a/src/Tests/Libs/Gio-2.0.Tests/DBusConnectionTest.cs
+++ b/src/Tests/Libs/Gio-2.0.Tests/DBusConnectionTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Gio.Tests
 {
     [TestClass, TestCategory("SystemTest")]
-    public class DBusConnectionTest
+    public class DBusConnectionTest : Test
     {
         [TestMethod]
         public void GetSessionBusShouldNotBeNull()

--- a/src/Tests/Libs/Gio-2.0.Tests/Test.cs
+++ b/src/Tests/Libs/Gio-2.0.Tests/Test.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Gio.Tests;
+
+public abstract class Test
+{
+    [TestCleanup]
+    public void Cleanup()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+    }
+}

--- a/src/Tests/Libs/Gtk-3.0.Tests/ConstructorTest.cs
+++ b/src/Tests/Libs/Gtk-3.0.Tests/ConstructorTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Gtk.Tests
 {
     [TestClass, TestCategory("SystemTest")]
-    public class ConstructorTest
+    public class ConstructorTest : Test
     {
         [TestMethod]
         public void WindowConstructorShouldSetTitle()

--- a/src/Tests/Libs/Gtk-3.0.Tests/PropertyTests.cs
+++ b/src/Tests/Libs/Gtk-3.0.Tests/PropertyTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Gtk.Tests
 {
     [TestClass, TestCategory("SystemTest")]
-    public class PropertyTests
+    public class PropertyTests : Test
     {
         [DataTestMethod]
         [DataRow(true)]

--- a/src/Tests/Libs/Gtk-3.0.Tests/SignalTest.cs
+++ b/src/Tests/Libs/Gtk-3.0.Tests/SignalTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Gtk.Tests
 {
     [TestClass, TestCategory("SystemTest")]
-    public class SignalTest
+    public class SignalTest : Test
     {
         [TestMethod]
         public void TestOnNotifySignal()

--- a/src/Tests/Libs/Gtk-3.0.Tests/Test.cs
+++ b/src/Tests/Libs/Gtk-3.0.Tests/Test.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Gtk.Tests;
+
+public abstract class Test
+{
+    [TestCleanup]
+    public void Cleanup()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+    }
+}


### PR DESCRIPTION
This enforces the garbage collector to collect all objects which can be freed. This uncovers if an object is freed by the garbage collector which is not freeable anymore.

Fixes #525 