### PR TITLE
Fix errors when closing the Cairo SafeHandle's

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.cs
@@ -1,11 +1,12 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace Cairo.Internal
 {
     public partial class Context
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_destroy")]
-        public static extern void Destroy(ContextOwnedHandle handle);
+        public static extern void Destroy(IntPtr handle);
 
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_fill")]
         public static extern void Fill(ContextHandle cr);

--- a/src/Libs/cairo-1.0/Internal/Records/ContextOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ContextOwnedHandle.cs
@@ -4,7 +4,7 @@
     {
         protected override partial bool ReleaseHandle()
         {
-            Context.Destroy(this);
+            Context.Destroy(handle);
             return true;
         }
     }

--- a/src/Libs/cairo-1.0/Internal/Records/Device.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Device.cs
@@ -6,6 +6,6 @@ namespace Cairo.Internal
     public partial class Device
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_device_destroy")]
-        public static extern void Destroy(DeviceOwnedHandle handle);
+        public static extern void Destroy(IntPtr handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/DeviceOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/DeviceOwnedHandle.cs
@@ -4,7 +4,7 @@
     {
         protected override partial bool ReleaseHandle()
         {
-            Device.Destroy(this);
+            Device.Destroy(handle);
             return true;
         }
     }

--- a/src/Libs/cairo-1.0/Internal/Records/FontFace.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontFace.cs
@@ -6,6 +6,6 @@ namespace Cairo.Internal
     public partial class FontFace
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_face_destroy")]
-        public static extern void Destroy(FontFaceOwnedHandle handle);
+        public static extern void Destroy(IntPtr handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/FontFaceOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontFaceOwnedHandle.cs
@@ -4,7 +4,7 @@
     {
         protected override partial bool ReleaseHandle()
         {
-            FontFace.Destroy(this);
+            FontFace.Destroy(handle);
             return true;
         }
     }

--- a/src/Libs/cairo-1.0/Internal/Records/FontOptions.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontOptions.cs
@@ -12,7 +12,7 @@ namespace Cairo.Internal
         public static extern FontOptionsOwnedHandle Create();
 
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_options_destroy")]
-        public static extern void Destroy(FontOptionsOwnedHandle handle);
+        public static extern void Destroy(IntPtr handle);
 
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_font_options_equal")]
         public static extern bool Equal(FontOptionsHandle handle, FontOptionsHandle other);

--- a/src/Libs/cairo-1.0/Internal/Records/FontOptionsOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontOptionsOwnedHandle.cs
@@ -4,7 +4,7 @@
     {
         protected override partial bool ReleaseHandle()
         {
-            FontOptions.Destroy(this);
+            FontOptions.Destroy(handle);
             return true;
         }
     }

--- a/src/Libs/cairo-1.0/Internal/Records/Path.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Path.cs
@@ -6,6 +6,6 @@ namespace Cairo.Internal
     public partial class Path
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_path_destroy")]
-        public static extern void Destroy(PathOwnedHandle handle);
+        public static extern void Destroy(IntPtr handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/PathOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/PathOwnedHandle.cs
@@ -4,7 +4,7 @@
     {
         protected override partial bool ReleaseHandle()
         {
-            Path.Destroy(this);
+            Path.Destroy(handle);
             return true;
         }
     }

--- a/src/Libs/cairo-1.0/Internal/Records/Pattern.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Pattern.cs
@@ -6,6 +6,6 @@ namespace Cairo.Internal
     public partial class Pattern
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_pattern_destroy")]
-        public static extern void Destroy(PatternOwnedHandle handle);
+        public static extern void Destroy(IntPtr handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/PatternOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/PatternOwnedHandle.cs
@@ -4,7 +4,7 @@
     {
         protected override partial bool ReleaseHandle()
         {
-            Pattern.Destroy(this);
+            Pattern.Destroy(handle);
             return true;
         }
     }

--- a/src/Libs/cairo-1.0/Internal/Records/Region.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Region.cs
@@ -6,6 +6,6 @@ namespace Cairo.Internal
     public partial class Region
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_region_destroy")]
-        public static extern void Destroy(RegionOwnedHandle handle);
+        public static extern void Destroy(IntPtr handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/RegionOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/RegionOwnedHandle.cs
@@ -4,7 +4,7 @@
     {
         protected override partial bool ReleaseHandle()
         {
-            Region.Destroy(this);
+            Region.Destroy(handle);
             return true;
         }
     }

--- a/src/Libs/cairo-1.0/Internal/Records/ScaledFont.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ScaledFont.cs
@@ -6,6 +6,6 @@ namespace Cairo.Internal
     public partial class ScaledFont
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_scaled_font_destroy")]
-        public static extern void Destroy(ScaledFontOwnedHandle handle);
+        public static extern void Destroy(IntPtr handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/ScaledFontOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ScaledFontOwnedHandle.cs
@@ -4,7 +4,7 @@
     {
         protected override partial bool ReleaseHandle()
         {
-            ScaledFont.Destroy(this);
+            ScaledFont.Destroy(handle);
             return true;
         }
     }

--- a/src/Libs/cairo-1.0/Internal/Records/Surface.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Surface.cs
@@ -1,11 +1,12 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace Cairo.Internal
 {
     public partial class Surface
     {
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_destroy")]
-        public static extern void Destroy(SurfaceOwnedHandle handle);
+        public static extern void Destroy(IntPtr handle);
 
         [DllImport(DllImportOverride.CairoLib, EntryPoint = "cairo_surface_create_similar")]
         public static extern SurfaceOwnedHandle CreateSimilar(SurfaceHandle handle, Content content, int width, int height);

--- a/src/Libs/cairo-1.0/Internal/Records/SurfaceOwnedHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/SurfaceOwnedHandle.cs
@@ -4,7 +4,7 @@
     {
         protected override partial bool ReleaseHandle()
         {
-            Surface.Destroy(this);
+            Surface.Destroy(handle);
             return true;
         }
     }


### PR DESCRIPTION
The Destroy() methods can't use the SafeHandle type. From https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.safehandle?view=net-6.0#what-safehandle-does, this will bump the SafeHandle's refcount and fail because the object is marked as closed (since this is in the Dispose() implementation)
So, these methods have to use a plain IntPtr instead.

Related to #598