### PR TITLE
Bump nuget versions

### DIFF
--- a/src/GirCore.Logging.props
+++ b/src/GirCore.Logging.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project>
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 </Project>

--- a/src/GirCore.Testing.props
+++ b/src/GirCore.Testing.props
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="Moq" Version="4.17.2" />
   </ItemGroup>


### PR DESCRIPTION
- Bump Serilog to 2.11.0
- Bump MSTest.TestAdapter to 2.2.10
- Bump MSTest.TestFramework to 2.2.10