### PR TITLE
Add bindings for Cairo.Region

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Records/Region.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Region.cs
@@ -5,7 +5,68 @@ namespace Cairo.Internal
 {
     public partial class Region
     {
+        // Not currently wrapped:
+        // - cairo_region_create_rectangles (needs to be an array of RectangleIntData?)
+        // - cairo_region_equal (if wrapped, need a hash function to go along with it)
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_contains_point")]
+        public static extern bool ContainsPoint(RegionHandle handle, int x, int y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_contains_rectangle")]
+        public static extern RegionOverlap ContainsRectangle(RegionHandle handle, RectangleIntHandle rectangle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_copy")]
+        public static extern RegionOwnedHandle Copy(RegionHandle original);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_create")]
+        public static extern RegionOwnedHandle Create();
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_create_rectangle")]
+        public static extern RegionOwnedHandle CreateRectangle(RectangleIntHandle rectangle);
+
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_destroy")]
         public static extern void Destroy(IntPtr handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_get_extents")]
+        public static extern void GetExtents(RegionHandle handle, RectangleIntHandle extents);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_get_rectangle")]
+        public static extern void GetRectangle(RegionHandle handle, int nth, RectangleIntHandle rectangle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_intersect")]
+        public static extern Status Intersect(RegionHandle handle, RegionHandle other);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_intersect_rectangle")]
+        public static extern Status IntersectRectangle(RegionHandle handle, RectangleIntHandle rectangle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_is_empty")]
+        public static extern bool IsEmpty(RegionHandle handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_num_rectangles")]
+        public static extern int NumRectangles(RegionHandle handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_status")]
+        public static extern Status Status(RegionHandle handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_subtract")]
+        public static extern Status Subtract(RegionHandle handle, RegionHandle other);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_subtract_rectangle")]
+        public static extern Status SubtractRectangle(RegionHandle handle, RectangleIntHandle rectangle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_translate")]
+        public static extern void Translate(RegionHandle handle, int x, int y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_union")]
+        public static extern Status Union(RegionHandle handle, RegionHandle other);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_union_rectangle")]
+        public static extern Status UnionRectangle(RegionHandle handle, RectangleIntHandle rectangle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_xor")]
+        public static extern Status Xor(RegionHandle handle, RegionHandle other);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_region_xor_rectangle")]
+        public static extern Status XorRectangle(RegionHandle handle, RectangleIntHandle rectangle);
     }
 }

--- a/src/Libs/cairo-1.0/Records/RectangleInt.cs
+++ b/src/Libs/cairo-1.0/Records/RectangleInt.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Cairo
+{
+    public partial class RectangleInt : IEquatable<RectangleInt>
+    {
+        public RectangleInt() :
+            this(Internal.RectangleIntManagedHandle.Create(new Internal.RectangleIntData()))
+        {
+        }
+
+        public override int GetHashCode() => Data.GetHashCode();
+
+        public override bool Equals(object? obj) => Equals(obj as RectangleInt);
+
+        public bool Equals(RectangleInt? other)
+            => other != null && Data.Equals(other.Data);
+
+        // Marshal the handle to / from a RectangleIntData struct.
+        private Internal.RectangleIntData Data
+        {
+            get => Marshal.PtrToStructure<Internal.RectangleIntData>(Handle.DangerousGetHandle());
+            set => Marshal.StructureToPtr(value, Handle.DangerousGetHandle(), false);
+        }
+
+        public int X
+        {
+            get => Data.X;
+            set => Data = Data with { X = value };
+        }
+
+        public int Y
+        {
+            get => Data.Y;
+            set => Data = Data with { Y = value };
+        }
+
+        public int Width
+        {
+            get => Data.Width;
+            set => Data = Data with { Width = value };
+        }
+
+        public int Height
+        {
+            get => Data.Height;
+            set => Data = Data with { Height = value };
+        }
+    }
+}

--- a/src/Libs/cairo-1.0/Records/Region.cs
+++ b/src/Libs/cairo-1.0/Records/Region.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+namespace Cairo
+{
+    public partial class Region
+    {
+        public Region()
+            : this(Internal.Region.Create())
+        {
+        }
+
+        public Region(RectangleInt rectangle)
+            : this(Internal.Region.CreateRectangle(rectangle.Handle))
+        {
+        }
+
+        public Region Copy() => new Region(Internal.Region.Copy(Handle));
+
+        public Status Status => Internal.Region.Status(Handle);
+
+        public bool IsEmpty => Internal.Region.IsEmpty(Handle);
+        public int NumRectangles => Internal.Region.NumRectangles(Handle);
+        public void GetRectangle(int i, RectangleInt rectangle)
+            => Internal.Region.GetRectangle(Handle, i, rectangle.Handle);
+        public void GetExtents(RectangleInt extents)
+            => Internal.Region.GetExtents(Handle, extents.Handle);
+
+        public bool ContainsPoint(int x, int y)
+            => Internal.Region.ContainsPoint(Handle, x, y);
+
+        public RegionOverlap ContainsRectangle(RectangleInt rectangle)
+            => Internal.Region.ContainsRectangle(Handle, rectangle.Handle);
+
+        public void Translate(int x, int y)
+            => Internal.Region.Translate(Handle, x, y);
+
+        public Status Intersect(Region other)
+            => Internal.Region.Intersect(Handle, other.Handle);
+
+        public Status IntersectRectangle(RectangleInt rectangle)
+            => Internal.Region.IntersectRectangle(Handle, rectangle.Handle);
+
+        public Status Subtract(Region other)
+            => Internal.Region.Subtract(Handle, other.Handle);
+
+        public Status SubtractRectangle(RectangleInt rectangle)
+            => Internal.Region.SubtractRectangle(Handle, rectangle.Handle);
+
+        public Status Union(Region other)
+            => Internal.Region.Union(Handle, other.Handle);
+
+        public Status UnionRectangle(RectangleInt rectangle)
+            => Internal.Region.UnionRectangle(Handle, rectangle.Handle);
+
+        public Status Xor(Region other)
+            => Internal.Region.Xor(Handle, other.Handle);
+
+        public Status XorRectangle(RectangleInt rectangle)
+            => Internal.Region.XorRectangle(Handle, rectangle.Handle);
+    }
+}

--- a/src/Tests/Libs/Cairo-1.0.Tests/RegionTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/RegionTest.cs
@@ -1,0 +1,58 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Cairo.Tests
+{
+    [TestClass, TestCategory("IntegrationTest")]
+    public class RegionTest : Test
+    {
+        [TestMethod]
+        public void BindingsShouldSucceed()
+        {
+            // Default constructor.
+            var empty_region = new Region();
+            empty_region.Status.Should().Be(Status.Success);
+            empty_region.IsEmpty.Should().Be(true);
+
+            // Rectangle constructor and accessors.
+            var rect_init = new RectangleInt() { X = 2, Y = 3, Height = 5, Width = 7 };
+            var region = new Region(rect_init);
+            region.Status.Should().Be(Status.Success);
+            region.IsEmpty.Should().Be(false);
+            region.NumRectangles.Should().Be(1);
+
+            var rect_copy = new RectangleInt();
+            region.GetRectangle(0, rect_copy);
+            rect_copy.Should().Be(rect_init);
+
+            rect_copy = new RectangleInt();
+            region.GetExtents(rect_copy);
+            rect_copy.Should().Be(rect_init);
+
+            region.Translate(1, 1);
+            rect_copy = new RectangleInt();
+            region.GetExtents(rect_copy);
+            rect_copy.Should().Be(new RectangleInt { X = 3, Y = 4, Height = 5, Width = 7 });
+
+            // Copying
+            var region_copy = region.Copy();
+            region_copy.Should().NotBeSameAs(rect_copy);
+            region_copy.NumRectangles.Should().Be(1);
+
+            // Queries
+            region.ContainsPoint(4, 4).Should().Be(true);
+            region.ContainsPoint(1, 1).Should().Be(false);
+            region.ContainsRectangle(rect_init).Should().Be(RegionOverlap.Part);
+
+            // Boolean operations
+            region.Intersect(region_copy).Should().Be(Status.Success);
+            region.Union(region_copy).Should().Be(Status.Success);
+            region.Subtract(region_copy).Should().Be(Status.Success);
+            region.Xor(region_copy).Should().Be(Status.Success);
+            region.IntersectRectangle(rect_init).Should().Be(Status.Success);
+            region.UnionRectangle(rect_init).Should().Be(Status.Success);
+            region.SubtractRectangle(rect_init).Should().Be(Status.Success);
+            region.XorRectangle(rect_init).Should().Be(Status.Success);
+        }
+    }
+}


### PR DESCRIPTION
This also adds some additional wrapper code for `Cairo.RectangleInt` in order to implement the unit tests (e.g. constructing a rectangle, comparing equality, and field accessors) - this is the main thing I'd like to discuss since it's a more general topic on the generator side of things!

The extra level of indirection to access the fields (`RectangleInt` vs `RectangleIntData`) feels kind of awkward - my current changes have some rough code that attempts to hide this. I feel like it would be more natural if the generator could just directly emit a `struct` type here, since on the C side this is a [plain struct](https://cairographics.org/manual/cairo-Types.html#cairo-rectangle-int-t) rather than an opaque / handle type

I think it might also make something like [cairo_region_create_rectangles()](https://cairographics.org/manual/cairo-Regions.html#cairo-region-create-rectangles) simpler to wrap as well since the memory layout would match 
The old cairo bindings from Mono / GtkSharp also made this a struct type, so changing from value to reference semantics would also make it tricky to port existing code correctly