### PR TITLE
Add more bindings for Cairo.Context

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.cs
@@ -5,11 +5,53 @@ namespace Cairo.Internal
 {
     public partial class Context
     {
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_create")]
+        public static extern ContextOwnedHandle Create(SurfaceHandle target);
+
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_destroy")]
         public static extern void Destroy(IntPtr handle);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_fill")]
         public static extern void Fill(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_antialias")]
+        public static extern Antialias GetAntialias(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_dash_count")]
+        public static extern int GetDashCount(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_dash")]
+        public static extern void GetDash(ContextHandle cr, double[] dashes, out double offset);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_fill_rule")]
+        public static extern FillRule GetFillRule(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_group_target")]
+        public static extern SurfaceUnownedHandle GetGroupTarget(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_line_cap")]
+        public static extern LineCap GetLineCap(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_line_join")]
+        public static extern LineJoin GetLineJoin(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_line_width")]
+        public static extern double GetLineWidth(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_miter_limit")]
+        public static extern double GetMiterLimit(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_operator")]
+        public static extern Operator GetOperator(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_tolerance")]
+        public static extern double GetTolerance(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_source")]
+        public static extern PatternUnownedHandle GetSource(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_target")]
+        public static extern SurfaceUnownedHandle GetTarget(ContextHandle cr);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_extents")]
         public static extern void FontExtents(ContextHandle cr, out FontExtents extents);
@@ -17,17 +59,74 @@ namespace Cairo.Internal
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_move_to")]
         public static extern void MoveTo(ContextHandle cr, double x, double y);
 
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pop_group")]
+        public static extern PatternOwnedHandle PopGroup(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pop_group_to_source")]
+        public static extern void PopGroupToSource(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_push_group")]
+        public static extern void PushGroup(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_push_group_with_content")]
+        public static extern void PushGroupWithContent(ContextHandle cr, Content content);
+
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_rectangle")]
         public static extern void Rectangle(ContextHandle cr, double x, double y, double width, double height);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_restore")]
+        public static extern void Restore(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_save")]
+        public static extern void Save(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_antialias")]
+        public static extern void SetAntialias(ContextHandle cr, Antialias antialias);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_dash")]
+        public static extern void SetDash(ContextHandle cr, double[] dashes, int num_dashes, double offset);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_fill_rule")]
+        public static extern void SetFillRule(ContextHandle cr, FillRule fill_rule);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_font_size")]
         public static extern void SetFontSize(ContextHandle cr, double size);
 
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_line_cap")]
+        public static extern void SetLineCap(ContextHandle cr, LineCap line_cap);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_line_join")]
+        public static extern void SetLineJoin(ContextHandle cr, LineJoin line_join);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_line_width")]
+        public static extern void SetLineWidth(ContextHandle cr, double width);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_miter_limit")]
+        public static extern void SetMiterLimit(ContextHandle cr, double limit);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_operator")]
+        public static extern void SetOperator(ContextHandle cr, Operator op);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_source")]
+        public static extern void SetSource(ContextHandle cr, PatternHandle source);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_source_rgb")]
+        public static extern void SetSourceRgb(ContextHandle cr, double red, double green, double blue);
+
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_source_rgba")]
         public static extern void SetSourceRgba(ContextHandle cr, double red, double green, double blue, double alpha);
 
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_source_surface")]
+        public static extern void SetSourceSurface(ContextHandle cr, SurfaceHandle surface, double x, double y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_tolerance")]
+        public static extern void SetTolerance(ContextHandle cr, double tolerance);
+
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_show_text")]
         public static extern void ShowText(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_status")]
+        public static extern Status Status(ContextHandle cr);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_text_extents")]
         public static extern void TextExtents(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8, out TextExtents extents);

--- a/src/Libs/cairo-1.0/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Records/Context.cs
@@ -2,6 +2,117 @@
 {
     public partial class Context
     {
+        public Context(Surface target)
+            : this(Internal.Context.Create(target.Handle))
+        {
+        }
+
+        public Status Status => Internal.Context.Status(Handle);
+
+        public void Save() => Internal.Context.Save(Handle);
+
+        public void Restore() => Internal.Context.Restore(Handle);
+
+        public Surface GetTarget()
+            => new Surface(Internal.Context.GetTarget(Handle));
+
+        #region Groups
+        public void PushGroup()
+            => Internal.Context.PushGroup(Handle);
+
+        public void PushGroupWithContent(Content content)
+            => Internal.Context.PushGroupWithContent(Handle, content);
+
+        public Pattern PopGroup()
+            => new Pattern(Internal.Context.PopGroup(Handle));
+
+        public void PopGroupToSource()
+            => Internal.Context.PopGroupToSource(Handle);
+
+        public Surface GetGroupTarget()
+            => new Surface(Internal.Context.GetGroupTarget(Handle));
+        #endregion
+
+        #region Source Pattern
+        public void SetSourceRgb(double red, double green, double blue)
+            => Internal.Context.SetSourceRgb(Handle, red, green, blue);
+
+        public void SetSourceRgba(double red, double green, double blue, double alpha)
+            => Internal.Context.SetSourceRgba(Handle, red, green, blue, alpha);
+
+        public void SetSource(Pattern source)
+            => Internal.Context.SetSource(Handle, source.Handle);
+
+        public void SetSourceSurface(Surface surface, double x, double y)
+            => Internal.Context.SetSourceSurface(Handle, surface.Handle, x, y);
+
+        public Pattern GetSource()
+            => new Pattern(Internal.Context.GetSource(Handle));
+        #endregion
+
+        #region Properties
+        public Antialias Antialias
+        {
+            get => Internal.Context.GetAntialias(Handle);
+            set => Internal.Context.SetAntialias(Handle, value);
+        }
+
+        public FillRule FillRule
+        {
+            get => Internal.Context.GetFillRule(Handle);
+            set => Internal.Context.SetFillRule(Handle, value);
+        }
+
+        public LineCap LineCap
+        {
+            get => Internal.Context.GetLineCap(Handle);
+            set => Internal.Context.SetLineCap(Handle, value);
+        }
+
+        public LineJoin LineJoin
+        {
+            get => Internal.Context.GetLineJoin(Handle);
+            set => Internal.Context.SetLineJoin(Handle, value);
+        }
+
+        public double LineWidth
+        {
+            get => Internal.Context.GetLineWidth(Handle);
+            set => Internal.Context.SetLineWidth(Handle, value);
+        }
+
+        public double MiterLimit
+        {
+            get => Internal.Context.GetMiterLimit(Handle);
+            set => Internal.Context.SetMiterLimit(Handle, value);
+        }
+
+        public Operator Operator
+        {
+            get => Internal.Context.GetOperator(Handle);
+            set => Internal.Context.SetOperator(Handle, value);
+        }
+
+        public double Tolerance
+        {
+            get => Internal.Context.GetTolerance(Handle);
+            set => Internal.Context.SetTolerance(Handle, value);
+        }
+        #endregion
+
+        #region Dash
+        public void SetDash(double[] dashes, double offset)
+            => Internal.Context.SetDash(Handle, dashes, dashes.Length, offset);
+
+        public int DashCount => Internal.Context.GetDashCount(Handle);
+
+        public void GetDash(out double[] dashes, out double offset)
+        {
+            dashes = new double[DashCount];
+            Internal.Context.GetDash(Handle, dashes, out offset);
+        }
+        #endregion
+
         public void Fill()
             => Internal.Context.Fill(Handle);
 
@@ -16,9 +127,6 @@
 
         public void SetFontSize(double size)
             => Internal.Context.SetFontSize(Handle, size);
-
-        public void SetSourceRgba(double red, double green, double blue, double alpha)
-            => Internal.Context.SetSourceRgba(Handle, red, green, blue, alpha);
 
         public void ShowText(string text)
             => Internal.Context.ShowText(Handle, text);

--- a/src/Tests/Libs/Cairo-1.0.Tests/ContextTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/ContextTest.cs
@@ -1,0 +1,66 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Cairo.Tests
+{
+    [TestClass, TestCategory("IntegrationTest")]
+    public class ContextTest : Test
+    {
+        [TestMethod]
+        public void BindingsShouldSucceed()
+        {
+            var surf = new ImageSurface(Format.Argb32, 400, 300);
+            var cr = new Context(surf);
+            cr.Status.Should().Be(Status.Success);
+            cr.GetTarget().Status.Should().Be(Status.Success);
+
+            cr.Save();
+            cr.Restore();
+
+            cr.PushGroup();
+            var pattern = cr.PopGroup();
+            pattern.Should().NotBeNull();
+            cr.SetSource(pattern);
+            cr.PushGroupWithContent(Content.Alpha);
+            cr.PopGroupToSource();
+            cr.GetGroupTarget().Status.Should().Be(Status.Success);
+
+            cr.SetSourceRgb(0.1, 0.2, 0.3);
+            cr.SetSourceRgba(0.1, 0.2, 0.3, 0.4);
+            cr.SetSourceSurface(new ImageSurface(Format.Argb32, 16, 16), 0, 0);
+            cr.GetSource().Should().NotBeNull();
+
+            cr.Antialias = Antialias.Gray;
+            cr.Antialias.Should().Be(Antialias.Gray);
+
+            cr.FillRule = FillRule.EvenOdd;
+            cr.FillRule.Should().Be(FillRule.EvenOdd);
+
+            cr.LineCap = LineCap.Round;
+            cr.LineCap.Should().Be(LineCap.Round);
+
+            cr.LineJoin = LineJoin.Bevel;
+            cr.LineJoin.Should().Be(LineJoin.Bevel);
+
+            cr.LineWidth = 42;
+            cr.LineWidth.Should().Be(42);
+
+            cr.MiterLimit = 2.4;
+            cr.MiterLimit.Should().Be(2.4);
+
+            cr.Operator = Operator.Atop;
+            cr.Operator.Should().Be(Operator.Atop);
+
+            cr.Tolerance = 3.4;
+            cr.Tolerance.Should().Be(3.4);
+
+            cr.SetDash(new double[] { 1, 2, 1, 4 }, 0.2);
+            cr.Status.Should().Be(Status.Success);
+            cr.DashCount.Should().Be(4);
+
+            cr.GetDash(out var dash_pattern, out var dash_offset);
+            dash_pattern.Should().BeEquivalentTo(new double[] { 1, 2, 1, 4 });
+            dash_offset.Should().Be(0.2);
+        }
+    }
+}


### PR DESCRIPTION
This adds many of the main `Cairo.Context` methods from https://cairographics.org/manual/cairo-cairo-t.html, but I stopped partway through to keep the diff at a reasonable size
These are all pretty straightforward, except the get_dash() family of functions which have a slightly more complex API

I'll also just note that methods like `GetTarget()` will also be related to #584 for how unowned handles behave when constructing a record