### PR TITLE
Add the remaining general Cairo.Context bindings

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.cs
@@ -5,6 +5,21 @@ namespace Cairo.Internal
 {
     public partial class Context
     {
+        // TODO
+        // - Bindings for cairo_copy_clip_rectangle_list() (cairo_rectangle_list_t)
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_clip")]
+        public static extern void Clip(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_clip_extents")]
+        public static extern void ClipExtents(ContextHandle cr, out double x1, out double y1, out double x2, out double y2);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_clip_preserve")]
+        public static extern void ClipPreserve(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_copy_page")]
+        public static extern void CopyPage(ContextHandle cr);
+
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_create")]
         public static extern ContextOwnedHandle Create(SurfaceHandle target);
 
@@ -13,6 +28,15 @@ namespace Cairo.Internal
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_fill")]
         public static extern void Fill(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_fill_preserve")]
+        public static extern void FillPreserve(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_fill_extents")]
+        public static extern void FillExtents(ContextHandle cr, out double x1, out double y1, out double x2, out double y2);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_extents")]
+        public static extern void FontExtents(ContextHandle cr, out FontExtents extents);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_antialias")]
         public static extern Antialias GetAntialias(ContextHandle cr);
@@ -53,11 +77,29 @@ namespace Cairo.Internal
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_target")]
         public static extern SurfaceUnownedHandle GetTarget(ContextHandle cr);
 
-        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_extents")]
-        public static extern void FontExtents(ContextHandle cr, out FontExtents extents);
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_in_clip")]
+        public static extern bool InClip(ContextHandle cr, double x, double y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_in_fill")]
+        public static extern bool InFill(ContextHandle cr, double x, double y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_in_stroke")]
+        public static extern bool InStroke(ContextHandle cr, double x, double y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_mask")]
+        public static extern void Mask(ContextHandle cr, PatternHandle pattern);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_mask_surface")]
+        public static extern void MaskSurface(ContextHandle cr, SurfaceHandle surface, double surface_x, double surface_y);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_move_to")]
         public static extern void MoveTo(ContextHandle cr, double x, double y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_paint")]
+        public static extern void Paint(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_paint_with_alpha")]
+        public static extern void PaintWithAlpha(ContextHandle cr, double alpha);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pop_group")]
         public static extern PatternOwnedHandle PopGroup(ContextHandle cr);
@@ -73,6 +115,9 @@ namespace Cairo.Internal
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_rectangle")]
         public static extern void Rectangle(ContextHandle cr, double x, double y, double width, double height);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_reset_clip")]
+        public static extern void ResetClip(ContextHandle cr);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_restore")]
         public static extern void Restore(ContextHandle cr);
@@ -122,11 +167,23 @@ namespace Cairo.Internal
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_tolerance")]
         public static extern void SetTolerance(ContextHandle cr, double tolerance);
 
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_show_page")]
+        public static extern void ShowPage(ContextHandle cr);
+
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_show_text")]
         public static extern void ShowText(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_status")]
         public static extern Status Status(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_stroke")]
+        public static extern void Stroke(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_stroke_preserve")]
+        public static extern void StrokePreserve(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_stroke_extents")]
+        public static extern void StrokeExtents(ContextHandle cr, out double x1, out double y1, out double x2, out double y2);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_text_extents")]
         public static extern void TextExtents(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8, out TextExtents extents);

--- a/src/Libs/cairo-1.0/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Records/Context.cs
@@ -113,8 +113,68 @@
         }
         #endregion
 
+        #region Clip
+        public void Clip()
+            => Internal.Context.Clip(Handle);
+
+        public void ClipPreserve()
+            => Internal.Context.ClipPreserve(Handle);
+
+        public void ClipExtents(out double x1, out double y1, out double x2, out double y2)
+            => Internal.Context.ClipExtents(Handle, out x1, out y1, out x2, out y2);
+
+        public bool InClip(double x, double y)
+            => Internal.Context.InClip(Handle, x, y);
+
+        public void ResetClip()
+            => Internal.Context.ResetClip(Handle);
+        #endregion
+
+        #region Drawing
         public void Fill()
             => Internal.Context.Fill(Handle);
+
+        public void FillPreserve()
+            => Internal.Context.FillPreserve(Handle);
+
+        public void FillExtents(out double x1, out double y1, out double x2, out double y2)
+            => Internal.Context.FillExtents(Handle, out x1, out y1, out x2, out y2);
+
+        public bool InFill(double x, double y)
+            => Internal.Context.InFill(Handle, x, y);
+
+        public void Mask(Pattern source)
+            => Internal.Context.Mask(Handle, source.Handle);
+
+        public void MaskSurface(Surface surface, double surface_x, double surface_y)
+            => Internal.Context.MaskSurface(Handle, surface.Handle, surface_x, surface_y);
+
+        public void Paint()
+            => Internal.Context.Paint(Handle);
+
+        public void PaintWithAlpha(double alpha)
+            => Internal.Context.PaintWithAlpha(Handle, alpha);
+
+        public void Stroke()
+            => Internal.Context.Stroke(Handle);
+
+        public void StrokePreserve()
+            => Internal.Context.StrokePreserve(Handle);
+
+        public void StrokeExtents(out double x1, out double y1, out double x2, out double y2)
+            => Internal.Context.StrokeExtents(Handle, out x1, out y1, out x2, out y2);
+
+        public bool InStroke(double x, double y)
+            => Internal.Context.InStroke(Handle, x, y);
+        #endregion
+
+        #region Pages
+        public void CopyPage()
+            => Internal.Context.CopyPage(Handle);
+
+        public void ShowPage()
+            => Internal.Context.ShowPage(Handle);
+        #endregion
 
         public void FontExtents(out FontExtents extents)
             => Internal.Context.FontExtents(Handle, out extents);

--- a/src/Tests/Libs/Cairo-1.0.Tests/ContextTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/ContextTest.cs
@@ -61,6 +61,34 @@ namespace Cairo.Tests
             cr.GetDash(out var dash_pattern, out var dash_offset);
             dash_pattern.Should().BeEquivalentTo(new double[] { 1, 2, 1, 4 });
             dash_offset.Should().Be(0.2);
+
+            cr.Clip();
+            cr.ClipPreserve();
+            cr.ClipExtents(out double x1, out double y1, out double x2, out double y2);
+            x2.Should().Be(0.0); // Empty since no shapes were drawn.
+            cr.InClip(2.2, 3.2).Should().Be(false);
+            cr.ResetClip();
+
+            cr.Fill();
+            cr.FillPreserve();
+            cr.FillExtents(out x1, out y1, out x2, out y2);
+            x2.Should().Be(0.0);
+            cr.InFill(2.2, 3.2).Should().Be(false);
+
+            cr.Mask(pattern);
+            cr.MaskSurface(new ImageSurface(Format.Argb32, 16, 16), 0, 0);
+
+            cr.Paint();
+            cr.PaintWithAlpha(0.5);
+
+            cr.Stroke();
+            cr.StrokePreserve();
+            cr.StrokeExtents(out x1, out y1, out x2, out y2);
+            x2.Should().Be(0.0);
+            cr.InStroke(2.2, 3.2).Should().Be(false);
+
+            cr.CopyPage();
+            cr.ShowPage();
         }
     }
 }


### PR DESCRIPTION
This is a followup to #624 and adds the remaining bindings from https://cairographics.org/manual/cairo-cairo-t.html.
The one exception is `cairo_copy_clip_rectangle_list()`, which probably needs some special wrapping since `cairo_rectangle_list_t` isn't very friendly to expose directly in C#