### PR TITLE
Add Cairo.Context bindings related to paths

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Records/Context.Paths.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.Paths.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Cairo.Internal
+{
+    public partial class Context
+    {
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_append_path")]
+        public static extern void AppendPath(ContextHandle cr, PathHandle path);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_arc")]
+        public static extern void Arc(ContextHandle cr, double xc, double yc, double radius, double angle1, double angle2);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_arc_negative")]
+        public static extern void ArcNegative(ContextHandle cr, double xc, double yc, double radius, double angle1, double angle2);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_close_path")]
+        public static extern void ClosePath(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_copy_path")]
+        public static extern PathOwnedHandle CopyPath(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_copy_path_flat")]
+        public static extern PathOwnedHandle CopyPathFlat(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_curve_to")]
+        public static extern void CurveTo(ContextHandle cr, double x1, double y1, double x2, double y2, double x3, double y3);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_current_point")]
+        public static extern void GetCurrentPoint(ContextHandle cr, out double x, out double y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_has_current_point")]
+        public static extern bool HasCurrentPoint(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_line_to")]
+        public static extern void LineTo(ContextHandle cr, double x, double y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_move_to")]
+        public static extern void MoveTo(ContextHandle cr, double x, double y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_new_path")]
+        public static extern void NewPath(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_new_sub_path")]
+        public static extern void NewSubPath(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_path_extents")]
+        public static extern void PathExtents(ContextHandle cr, out double x1, out double y1, out double x2, out double y2);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_rectangle")]
+        public static extern void Rectangle(ContextHandle cr, double x, double y, double width, double height);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_rel_curve_to")]
+        public static extern void RelCurveTo(ContextHandle cr, double x1, double y1, double x2, double y2, double x3, double y3);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_rel_line_to")]
+        public static extern void RelLineTo(ContextHandle cr, double x, double y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_rel_move_to")]
+        public static extern void RelMoveTo(ContextHandle cr, double x, double y);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_text_path")]
+        public static extern void TextPath(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8);
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.cs
@@ -92,9 +92,6 @@ namespace Cairo.Internal
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_mask_surface")]
         public static extern void MaskSurface(ContextHandle cr, SurfaceHandle surface, double surface_x, double surface_y);
 
-        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_move_to")]
-        public static extern void MoveTo(ContextHandle cr, double x, double y);
-
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_paint")]
         public static extern void Paint(ContextHandle cr);
 
@@ -112,9 +109,6 @@ namespace Cairo.Internal
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_push_group_with_content")]
         public static extern void PushGroupWithContent(ContextHandle cr, Content content);
-
-        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_rectangle")]
-        public static extern void Rectangle(ContextHandle cr, double x, double y, double width, double height);
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_reset_clip")]
         public static extern void ResetClip(ContextHandle cr);

--- a/src/Libs/cairo-1.0/Records/Context.Paths.cs
+++ b/src/Libs/cairo-1.0/Records/Context.Paths.cs
@@ -1,0 +1,65 @@
+﻿namespace Cairo
+{
+    public partial class Context
+    {
+        // TODO
+        // - Add cairo_glyph_path(), which requires cairo_glyph_t from the text API.
+
+        public Path CopyPath()
+            => new Path(Internal.Context.CopyPath(Handle));
+
+        public Path CopyPathFlat()
+            => new Path(Internal.Context.CopyPathFlat(Handle));
+
+        public void AppendPath(Path path)
+            => Internal.Context.AppendPath(Handle, path.Handle);
+
+        public bool HasCurrentPoint
+            => Internal.Context.HasCurrentPoint(Handle);
+
+        public void GetCurrentPoint(out double x, out double y)
+            => Internal.Context.GetCurrentPoint(Handle, out x, out y);
+
+        public void NewPath()
+            => Internal.Context.NewPath(Handle);
+
+        public void NewSubPath()
+            => Internal.Context.NewSubPath(Handle);
+
+        public void ClosePath()
+            => Internal.Context.ClosePath(Handle);
+
+        public void Arc(double xc, double yc, double radius, double angle1, double angle2)
+            => Internal.Context.Arc(Handle, xc, yc, radius, angle1, angle2);
+
+        public void ArcNegative(double xc, double yc, double radius, double angle1, double angle2)
+            => Internal.Context.ArcNegative(Handle, xc, yc, radius, angle1, angle2);
+
+        public void CurveTo(double x1, double y1, double x2, double y2, double x3, double y3)
+            => Internal.Context.CurveTo(Handle, x1, y1, x2, y2, x3, y3);
+
+        public void LineTo(double x, double y)
+            => Internal.Context.LineTo(Handle, x, y);
+
+        public void MoveTo(double x, double y)
+            => Internal.Context.MoveTo(Handle, x, y);
+
+        public void Rectangle(double x, double y, double width, double height)
+            => Internal.Context.Rectangle(Handle, x, y, width, height);
+
+        public void TextPath(string text)
+            => Internal.Context.TextPath(Handle, text);
+
+        public void RelCurveTo(double x1, double y1, double x2, double y2, double x3, double y3)
+            => Internal.Context.RelCurveTo(Handle, x1, y1, x2, y2, x3, y3);
+
+        public void RelLineTo(double x, double y)
+            => Internal.Context.RelLineTo(Handle, x, y);
+
+        public void RelMoveTo(double x, double y)
+            => Internal.Context.RelMoveTo(Handle, x, y);
+
+        public void PathExtents(out double x1, out double y1, out double x2, out double y2)
+            => Internal.Context.PathExtents(Handle, out x1, out y1, out x2, out y2);
+    }
+}

--- a/src/Libs/cairo-1.0/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Records/Context.cs
@@ -179,12 +179,6 @@
         public void FontExtents(out FontExtents extents)
             => Internal.Context.FontExtents(Handle, out extents);
 
-        public void MoveTo(double x, double y)
-            => Internal.Context.MoveTo(Handle, x, y);
-
-        public void Rectangle(double x, double y, double width, double height)
-            => Internal.Context.Rectangle(Handle, x, y, width, height);
-
         public void SetFontSize(double size)
             => Internal.Context.SetFontSize(Handle, size);
 

--- a/src/Tests/Libs/Cairo-1.0.Tests/ContextTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/ContextTest.cs
@@ -89,6 +89,39 @@ namespace Cairo.Tests
 
             cr.CopyPage();
             cr.ShowPage();
+
+            Path path = cr.CopyPath();
+            path.Should().NotBeNull();
+
+            cr.NewPath();
+            cr.AppendPath(path);
+            cr.ClosePath();
+
+            path = cr.CopyPathFlat();
+            path.Should().NotBeNull();
+            cr.NewSubPath();
+
+            cr.Arc(0, 0, 2.0, 0, 2 * System.Math.PI);
+
+            cr.HasCurrentPoint.Should().Be(true);
+            cr.GetCurrentPoint(out double x, out double y);
+            x.Should().Be(2);
+            y.Should().Be(0);
+
+            cr.ArcNegative(0, 0, 2.0, 0, 2 * System.Math.PI);
+            cr.CurveTo(1, 2, 3, 4, 5, 6);
+
+            cr.MoveTo(1, 2);
+            cr.LineTo(3, 4);
+            cr.Rectangle(1, 2, 3, 4);
+            cr.TextPath("foo");
+
+            cr.RelCurveTo(1, 2, 3, 4, 5, 6);
+            cr.RelMoveTo(1, 2);
+            cr.RelLineTo(3, 4);
+
+            cr.PathExtents(out x1, out y1, out x2, out y2);
+            x1.Should().Be(-2.0);
         }
     }
 }


### PR DESCRIPTION
Following #590 I've put these into a separate `Context.Paths.cs` file for organization, but the API is still under `Cairo.Context`

This adds everything from https://cairographics.org/manual/cairo-Paths.html, except for `cairo_glyph_path()` which is left until bindings are done for https://cairographics.org/manual/cairo-text.html