### PR TITLE
Add bindings for Cairo.Pattern

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Records/MatrixData.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/MatrixData.cs
@@ -1,0 +1,13 @@
+﻿namespace Cairo.Internal
+{
+    // The gir file does not contain the fields for Cairo.Matrix
+    public partial struct MatrixData
+    {
+        public double Xx;
+        public double Yx;
+        public double Xy;
+        public double Yy;
+        public double X0;
+        public double Y0;
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/Pattern.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Pattern.cs
@@ -5,7 +5,69 @@ namespace Cairo.Internal
 {
     public partial class Pattern
     {
+        // TODO - expose cairo_pattern_create_mesh() and related methods.
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_add_color_stop_rgb")]
+        public static extern void AddColorStopRgb(PatternHandle pattern, double offset, double r, double g, double b);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_add_color_stop_rgba")]
+        public static extern void AddColorStopRgba(PatternHandle pattern, double offset, double r, double g, double b, double a);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_create_linear")]
+        public static extern PatternOwnedHandle CreateLinear(double x0, double y0, double x1, double y1);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_create_radial")]
+        public static extern PatternOwnedHandle CreateRadial(double cx0, double cy0, double radius0, double cx1, double cy1, double radius1);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_create_rgb")]
+        public static extern PatternOwnedHandle CreateRgb(double r, double g, double b);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_create_rgba")]
+        public static extern PatternOwnedHandle CreateRgba(double r, double g, double b, double a);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_create_for_surface")]
+        public static extern PatternOwnedHandle CreateForSurface(SurfaceHandle surface);
+
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_destroy")]
         public static extern void Destroy(IntPtr handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_get_color_stop_count")]
+        public static extern Status GetColorStopCount(PatternHandle pattern, out int count);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_get_color_stop_rgba")]
+        public static extern Status GetColorStopRgba(PatternHandle pattern, int index, out double offset, out double r, out double g, out double b, out double a);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_get_extend")]
+        public static extern Extend GetExtend(PatternHandle pattern);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_get_filter")]
+        public static extern Filter GetFilter(PatternHandle pattern);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_get_linear_points")]
+        public static extern Status GetLinearPoints(PatternHandle pattern, out double x0, out double y0, out double x1, out double y1);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_get_matrix")]
+        public static extern void GetMatrix(PatternHandle pattern, MatrixHandle matrix);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_get_rgba")]
+        public static extern Status GetRgba(PatternHandle pattern, out double r, out double g, out double b, out double a);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_get_surface")]
+        public static extern Status GetSurface(PatternHandle pattern, out SurfaceUnownedHandle surface);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_get_type")]
+        public static extern PatternType GetType(PatternHandle pattern);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_set_extend")]
+        public static extern void SetExtend(PatternHandle pattern, Extend extend);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_set_filter")]
+        public static extern void SetFilter(PatternHandle pattern, Filter filter);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_set_matrix")]
+        public static extern void SetMatrix(PatternHandle pattern, MatrixHandle matrix);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_pattern_status")]
+        public static extern Status Status(PatternHandle pattern);
     }
 }

--- a/src/Libs/cairo-1.0/Records/Gradient.cs
+++ b/src/Libs/cairo-1.0/Records/Gradient.cs
@@ -1,0 +1,28 @@
+﻿namespace Cairo
+{
+    public class Gradient : Pattern
+    {
+        protected Gradient(Internal.PatternHandle handle)
+            : base(handle)
+        {
+        }
+
+        public void AddColorStopRgb(double offset, double r, double g, double b)
+            => Internal.Pattern.AddColorStopRgb(Handle, offset, r, g, b);
+
+        public void AddColorStopRgba(double offset, double r, double g, double b, double a)
+            => Internal.Pattern.AddColorStopRgba(Handle, offset, r, g, b, a);
+
+        public int ColorStopCount
+        {
+            get
+            {
+                Internal.Pattern.GetColorStopCount(Handle, out int count);
+                return count;
+            }
+        }
+
+        public Status GetColorStopRgba(int index, out double offset, out double r, out double g, out double b, out double a)
+            => Internal.Pattern.GetColorStopRgba(Handle, index, out offset, out r, out g, out b, out a);
+    }
+}

--- a/src/Libs/cairo-1.0/Records/LinearGradient.cs
+++ b/src/Libs/cairo-1.0/Records/LinearGradient.cs
@@ -1,0 +1,13 @@
+﻿namespace Cairo
+{
+    public class LinearGradient : Gradient
+    {
+        public LinearGradient(double x0, double y0, double x1, double y1)
+            : base(Internal.Pattern.CreateLinear(x0, y0, x1, y1))
+        {
+        }
+
+        public Status GetLinearPoints(out double x0, out double y0, out double x1, out double y1)
+            => Internal.Pattern.GetLinearPoints(Handle, out x0, out y0, out x1, out y1);
+    }
+}

--- a/src/Libs/cairo-1.0/Records/Pattern.cs
+++ b/src/Libs/cairo-1.0/Records/Pattern.cs
@@ -1,0 +1,27 @@
+﻿namespace Cairo
+{
+    public partial class Pattern
+    {
+        public Status Status => Internal.Pattern.Status(Handle);
+
+        public PatternType PatternType => Internal.Pattern.GetType(Handle);
+
+        public Extend Extend
+        {
+            get => Internal.Pattern.GetExtend(Handle);
+            set => Internal.Pattern.SetExtend(Handle, value);
+        }
+
+        public Filter Filter
+        {
+            get => Internal.Pattern.GetFilter(Handle);
+            set => Internal.Pattern.SetFilter(Handle, value);
+        }
+
+        public void GetMatrix(Matrix matrix)
+            => Internal.Pattern.GetMatrix(Handle, matrix.Handle);
+
+        public void SetMatrix(Matrix matrix)
+            => Internal.Pattern.SetMatrix(Handle, matrix.Handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Records/RadialGradient.cs
+++ b/src/Libs/cairo-1.0/Records/RadialGradient.cs
@@ -1,0 +1,10 @@
+﻿namespace Cairo
+{
+    public class RadialGradient : Gradient
+    {
+        public RadialGradient(double cx0, double cy0, double radius0, double cx1, double cy1, double radius1)
+            : base(Internal.Pattern.CreateRadial(cx0, cy0, radius0, cx1, cy1, radius1))
+        {
+        }
+    }
+}

--- a/src/Libs/cairo-1.0/Records/SolidPattern.cs
+++ b/src/Libs/cairo-1.0/Records/SolidPattern.cs
@@ -1,0 +1,19 @@
+﻿namespace Cairo
+{
+    public class SolidPattern : Pattern
+    {
+        private SolidPattern(Internal.PatternHandle handle)
+            : base(handle)
+        {
+        }
+
+        public static SolidPattern CreateRgb(double r, double g, double b)
+            => new SolidPattern(Internal.Pattern.CreateRgb(r, g, b));
+
+        public static SolidPattern CreateRgba(double r, double g, double b, double a)
+            => new SolidPattern(Internal.Pattern.CreateRgba(r, g, b, a));
+
+        public Status GetRgba(out double r, out double g, out double b, out double a)
+            => Internal.Pattern.GetRgba(Handle, out r, out g, out b, out a);
+    }
+}

--- a/src/Libs/cairo-1.0/Records/SurfacePattern.cs
+++ b/src/Libs/cairo-1.0/Records/SurfacePattern.cs
@@ -1,0 +1,16 @@
+﻿namespace Cairo
+{
+    public class SurfacePattern : Pattern
+    {
+        public SurfacePattern(Surface surface)
+            : base(Internal.Pattern.CreateForSurface(surface.Handle))
+        {
+        }
+
+        public Surface GetSurface()
+        {
+            Internal.Pattern.GetSurface(Handle, out var surface_handle);
+            return new Surface(surface_handle);
+        }
+    }
+}

--- a/src/Tests/Libs/Cairo-1.0.Tests/PatternTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/PatternTest.cs
@@ -1,0 +1,56 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Cairo.Tests
+{
+    [TestClass, TestCategory("IntegrationTest")]
+    public class PatternTest : Test
+    {
+        [TestMethod]
+        public void BindingsShouldSucceed()
+        {
+            var solid_pattern = SolidPattern.CreateRgb(0.2, 0.3, 0.4);
+            solid_pattern.Status.Should().Be(Status.Success);
+
+            solid_pattern.Extend = Extend.Reflect;
+            solid_pattern.Extend.Should().Be(Extend.Reflect);
+
+            solid_pattern.Filter = Filter.Gaussian;
+            solid_pattern.Filter.Should().Be(Filter.Gaussian);
+
+            var matrix = new Matrix(Internal.MatrixManagedHandle.Create());
+            solid_pattern.GetMatrix(matrix);
+            solid_pattern.SetMatrix(matrix);
+
+            solid_pattern = SolidPattern.CreateRgba(0.2, 0.3, 0.4, 0.5);
+            solid_pattern.Status.Should().Be(Status.Success);
+            solid_pattern.PatternType.Should().Be(PatternType.Solid);
+
+            var status = solid_pattern.GetRgba(out double r, out double g, out double b, out double a);
+            status.Should().Be(Status.Success);
+            a.Should().Be(0.5);
+
+            var surf_pattern = new SurfacePattern(new ImageSurface(Format.Argb32, 32, 32));
+            surf_pattern.Status.Should().Be(Status.Success);
+
+            surf_pattern.PatternType.Should().Be(PatternType.Surface);
+            surf_pattern.GetSurface().Status.Should().Be(Status.Success);
+
+            var linear_pattern = new LinearGradient(1, 2, 3, 4);
+            linear_pattern.Status.Should().Be(Status.Success);
+
+            status = linear_pattern.GetLinearPoints(out double x0, out double y0, out double x1, out double y1);
+            status.Should().Be(Status.Success);
+            y1.Should().Be(4);
+
+            linear_pattern.AddColorStopRgba(0.1, 0.2, 0.3, 0.4, 0.5);
+            linear_pattern.ColorStopCount.Should().Be(1);
+            status = linear_pattern.GetColorStopRgba(0, out double offset, out r, out g, out b, out a);
+            status.Should().Be(Status.Success);
+            a.Should().Be(0.5);
+
+            var radial_pattern = new RadialGradient(1, 2, 3, 4, 5, 6);
+            radial_pattern.Status.Should().Be(Status.Success);
+        }
+    }
+}


### PR DESCRIPTION
This follows the suggested API structure from https://cairographics.org/manual/bindings-patterns.html. The "mesh" pattern type will be left for a separate PR

The unit tests revealed that Cairo.Internal.MatrixData was the wrong size (empty) since the fields aren't in the gir file, so those have been manually added