### PR TITLE
Add Cairo.Context text-related methods

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Records/Context.Text.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.Text.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Cairo.Internal
+{
+    public partial class Context
+    {
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_extents")]
+        public static extern void FontExtents(ContextHandle cr, out FontExtents extents);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_font_face")]
+        public static extern FontFaceUnownedHandle GetFontFace(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_font_matrix")]
+        public static extern void GetFontMatrix(ContextHandle cr, MatrixHandle matrix);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_font_options")]
+        public static extern void GetFontOptions(ContextHandle cr, FontOptionsHandle options);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_scaled_font")]
+        public static extern ScaledFontUnownedHandle GetScaledFont(ContextHandle cr);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_select_font_face")]
+        public static extern void SelectFontFace(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string family, FontSlant slant, FontWeight weight);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_font_face")]
+        public static extern void SetFontFace(ContextHandle cr, FontFaceHandle font_face);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_font_matrix")]
+        public static extern void SetFontMatrix(ContextHandle cr, MatrixHandle matrix);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_font_options")]
+        public static extern void SetFontOptions(ContextHandle cr, FontOptionsHandle options);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_font_size")]
+        public static extern void SetFontSize(ContextHandle cr, double size);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_scaled_font")]
+        public static extern void SetScaledFont(ContextHandle cr, ScaledFontHandle scaled_font);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_show_text")]
+        public static extern void ShowText(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_text_extents")]
+        public static extern void TextExtents(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8, out TextExtents extents);
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/Context.cs
@@ -35,9 +35,6 @@ namespace Cairo.Internal
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_fill_extents")]
         public static extern void FillExtents(ContextHandle cr, out double x1, out double y1, out double x2, out double y2);
 
-        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_extents")]
-        public static extern void FontExtents(ContextHandle cr, out FontExtents extents);
-
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_get_antialias")]
         public static extern Antialias GetAntialias(ContextHandle cr);
 
@@ -128,9 +125,6 @@ namespace Cairo.Internal
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_fill_rule")]
         public static extern void SetFillRule(ContextHandle cr, FillRule fill_rule);
 
-        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_font_size")]
-        public static extern void SetFontSize(ContextHandle cr, double size);
-
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_line_cap")]
         public static extern void SetLineCap(ContextHandle cr, LineCap line_cap);
 
@@ -164,9 +158,6 @@ namespace Cairo.Internal
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_show_page")]
         public static extern void ShowPage(ContextHandle cr);
 
-        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_show_text")]
-        public static extern void ShowText(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8);
-
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_status")]
         public static extern Status Status(ContextHandle cr);
 
@@ -178,8 +169,5 @@ namespace Cairo.Internal
 
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_stroke_extents")]
         public static extern void StrokeExtents(ContextHandle cr, out double x1, out double y1, out double x2, out double y2);
-
-        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_text_extents")]
-        public static extern void TextExtents(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8, out TextExtents extents);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/FontFace.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/FontFace.cs
@@ -7,5 +7,11 @@ namespace Cairo.Internal
     {
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_face_destroy")]
         public static extern void Destroy(IntPtr handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_face_get_type")]
+        public static extern FontType GetType(FontFaceHandle handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_face_status")]
+        public static extern Status Status(FontFaceHandle handle);
     }
 }

--- a/src/Libs/cairo-1.0/Internal/Records/ToyFontFace.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ToyFontFace.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Cairo.Internal
+{
+    public class ToyFontFace
+    {
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_toy_font_face_create")]
+        public static extern FontFaceOwnedHandle Create([MarshalAs(UnmanagedType.LPUTF8Str)] string family, FontSlant slant, FontWeight weight);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_toy_font_face_get_family")]
+        public static extern IntPtr GetFamily(FontFaceHandle handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_toy_font_face_get_slant")]
+        public static extern FontSlant GetSlant(FontFaceHandle handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_toy_font_face_get_weight")]
+        public static extern FontWeight GetWeight(FontFaceHandle handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Records/Context.Text.cs
+++ b/src/Libs/cairo-1.0/Records/Context.Text.cs
@@ -1,0 +1,49 @@
+﻿namespace Cairo
+{
+    public partial class Context
+    {
+        // TODO add method using cairo_glyph_t
+        // - cairo_show_glyphs()
+        // - cairo_show_text_glyphs()
+        // - cairo_glyph_extents()
+
+        public void SelectFontFace(string family, FontSlant slant, FontWeight weight)
+            => Internal.Context.SelectFontFace(Handle, family, slant, weight);
+
+        public void SetFontSize(double size)
+            => Internal.Context.SetFontSize(Handle, size);
+
+        public void SetFontMatrix(Matrix matrix)
+            => Internal.Context.SetFontMatrix(Handle, matrix.Handle);
+
+        public void GetFontMatrix(Matrix matrix)
+            => Internal.Context.GetFontMatrix(Handle, matrix.Handle);
+
+        public void SetFontOptions(FontOptions options)
+            => Internal.Context.SetFontOptions(Handle, options.Handle);
+
+        public void GetFontOptions(FontOptions options)
+            => Internal.Context.GetFontOptions(Handle, options.Handle);
+
+        public void SetFontFace(FontFace font_face)
+            => Internal.Context.SetFontFace(Handle, font_face.Handle);
+
+        public FontFace GetFontFace()
+            => new FontFace(Internal.Context.GetFontFace(Handle));
+
+        public void SetScaledFont(ScaledFont scaled_font)
+            => Internal.Context.SetScaledFont(Handle, scaled_font.Handle);
+
+        public ScaledFont GetScaledFont()
+            => new ScaledFont(Internal.Context.GetScaledFont(Handle));
+
+        public void ShowText(string text)
+            => Internal.Context.ShowText(Handle, text);
+
+        public void FontExtents(out FontExtents extents)
+            => Internal.Context.FontExtents(Handle, out extents);
+
+        public void TextExtents(string text, out TextExtents extents)
+            => Internal.Context.TextExtents(Handle, text, out extents);
+    }
+}

--- a/src/Libs/cairo-1.0/Records/Context.cs
+++ b/src/Libs/cairo-1.0/Records/Context.cs
@@ -175,17 +175,5 @@
         public void ShowPage()
             => Internal.Context.ShowPage(Handle);
         #endregion
-
-        public void FontExtents(out FontExtents extents)
-            => Internal.Context.FontExtents(Handle, out extents);
-
-        public void SetFontSize(double size)
-            => Internal.Context.SetFontSize(Handle, size);
-
-        public void ShowText(string text)
-            => Internal.Context.ShowText(Handle, text);
-
-        public void TextExtents(string text, out TextExtents extents)
-            => Internal.Context.TextExtents(Handle, text, out extents);
     }
 }

--- a/src/Libs/cairo-1.0/Records/FontFace.cs
+++ b/src/Libs/cairo-1.0/Records/FontFace.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Cairo
+{
+    public partial class FontFace
+    {
+        public Status Status => Internal.FontFace.Status(Handle);
+        public FontType FontType => Internal.FontFace.GetType(Handle);
+    }
+}

--- a/src/Libs/cairo-1.0/Records/ToyFontFace.cs
+++ b/src/Libs/cairo-1.0/Records/ToyFontFace.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Cairo
+{
+    public class ToyFontFace : FontFace
+    {
+        public ToyFontFace(string family, FontSlant slant, FontWeight weight)
+            : base(Internal.ToyFontFace.Create(family, slant, weight))
+        {
+        }
+
+        public string Family
+            => GLib.Internal.StringHelper.ToStringUtf8(Internal.ToyFontFace.GetFamily(Handle));
+
+        public FontSlant Slant => Internal.ToyFontFace.GetSlant(Handle);
+
+        public FontWeight Weight => Internal.ToyFontFace.GetWeight(Handle);
+    }
+}

--- a/src/Tests/Libs/Cairo-1.0.Tests/ContextTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/ContextTest.cs
@@ -122,6 +122,28 @@ namespace Cairo.Tests
 
             cr.PathExtents(out x1, out y1, out x2, out y2);
             x1.Should().Be(-2.0);
+
+            cr.SelectFontFace("serif", FontSlant.Italic, FontWeight.Bold);
+            var matrix = new Matrix(Internal.MatrixManagedHandle.Create());
+            cr.SetFontMatrix(matrix);
+            cr.GetFontMatrix(matrix);
+            cr.SetFontSize(12.0);
+
+            cr.FontExtents(out FontExtents font_extents);
+            font_extents.Height.Should().NotBe(0);
+
+            cr.TextExtents("foo", out TextExtents text_extents);
+            text_extents.Height.Should().NotBe(0);
+
+            var font_opts = new FontOptions();
+            cr.GetFontOptions(font_opts);
+            cr.SetFontOptions(font_opts);
+
+            var font_face = cr.GetFontFace();
+            cr.SetFontFace(font_face);
+
+            var scaled_font = cr.GetScaledFont();
+            cr.SetScaledFont(scaled_font);
         }
     }
 }

--- a/src/Tests/Libs/Cairo-1.0.Tests/FontFaceTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/FontFaceTest.cs
@@ -1,0 +1,20 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Cairo.Tests
+{
+    [TestClass, TestCategory("IntegrationTest")]
+    public class FontFaceTest : Test
+    {
+        [TestMethod]
+        public void BindingsShouldSucceed()
+        {
+            var face = new ToyFontFace("serif", FontSlant.Italic, FontWeight.Bold);
+            face.Status.Should().Be(Status.Success);
+            face.FontType.Should().Be(FontType.Toy);
+            face.Family.Should().Be("serif");
+            face.Slant.Should().Be(FontSlant.Italic);
+            face.Weight.Should().Be(FontWeight.Bold);
+        }
+    }
+}


### PR DESCRIPTION
This adds the methods from https://cairographics.org/manual/cairo-text.html, minus the `cairo_glyph_t` methods which require bindings for additional types.
The methods related to the toy font face API (`cairo_toy_font_face_create()` etc) have also been added