### PR TITLE
Add bindings for Cairo.ScaledFont

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Records/ScaledFont.cs
+++ b/src/Libs/cairo-1.0/Internal/Records/ScaledFont.cs
@@ -5,7 +5,37 @@ namespace Cairo.Internal
 {
     public partial class ScaledFont
     {
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_create")]
+        public static extern ScaledFontOwnedHandle Create(FontFaceHandle font_face, MatrixHandle font_matrix, MatrixHandle ctm, FontOptionsHandle options);
+
         [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_destroy")]
         public static extern void Destroy(IntPtr handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_extents")]
+        public static extern void Extents(ScaledFontHandle handle, out FontExtents extents);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_get_ctm")]
+        public static extern void GetCtm(ScaledFontHandle handle, MatrixHandle ctm);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_get_font_face")]
+        public static extern FontFaceUnownedHandle GetFontFace(ScaledFontHandle handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_get_font_matrix")]
+        public static extern void GetFontMatrix(ScaledFontHandle handle, MatrixHandle matrix);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_get_font_options")]
+        public static extern void GetFontOptions(ScaledFontHandle handle, FontOptionsHandle options);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_get_scale_matrix")]
+        public static extern void GetScaleMatrix(ScaledFontHandle handle, MatrixHandle matrix);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_get_type")]
+        public static extern FontType GetType(ScaledFontHandle handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_status")]
+        public static extern Status Status(ScaledFontHandle handle);
+
+        [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_text_extents")]
+        public static extern void TextExtents(ScaledFontHandle handle, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8, out TextExtents extents);
     }
 }

--- a/src/Libs/cairo-1.0/Records/ScaledFont.cs
+++ b/src/Libs/cairo-1.0/Records/ScaledFont.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Cairo
+{
+    public partial class ScaledFont
+    {
+        // TODO add methods using cairo_glyph_t
+        // - cairo_scaled_font_glyph_extents()
+        // - cairo_scaled_font_text_to_glyphs()
+
+        public ScaledFont(FontFace font_face, Matrix font_matrix, Matrix ctm, FontOptions options)
+            : this(Internal.ScaledFont.Create(font_face.Handle, font_matrix.Handle, ctm.Handle, options.Handle))
+        {
+        }
+
+        public Status Status => Internal.ScaledFont.Status(Handle);
+
+        public FontType FontType => Internal.ScaledFont.GetType(Handle);
+
+        public void Extents(out FontExtents extents)
+            => Internal.ScaledFont.Extents(Handle, out extents);
+
+        public void TextExtents(string text, out TextExtents extents)
+            => Internal.ScaledFont.TextExtents(Handle, text, out extents);
+
+        public FontFace GetFontFace()
+            => new FontFace(Internal.ScaledFont.GetFontFace(Handle));
+
+        public void GetFontOptions(FontOptions options)
+            => Internal.ScaledFont.GetFontOptions(Handle, options.Handle);
+
+        public void GetFontMatrix(Matrix matrix)
+            => Internal.ScaledFont.GetFontMatrix(Handle, matrix.Handle);
+
+        public void GetCtm(Matrix ctm)
+            => Internal.ScaledFont.GetCtm(Handle, ctm.Handle);
+
+        public void GetScaleMatrix(Matrix scale_matrix)
+            => Internal.ScaledFont.GetScaleMatrix(Handle, scale_matrix.Handle);
+    }
+}

--- a/src/Tests/Libs/Cairo-1.0.Tests/ScaledFontTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/ScaledFontTest.cs
@@ -1,0 +1,36 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Cairo.Tests
+{
+    [TestClass, TestCategory("IntegrationTest")]
+    public class ScaledFontTest : Test
+    {
+        [TestMethod]
+        public void BindingsShouldSucceed()
+        {
+            var face = new ToyFontFace("serif", FontSlant.Italic, FontWeight.Bold);
+            var matrix = new Matrix(Internal.MatrixManagedHandle.Create());
+            var ctm = new Matrix(Internal.MatrixManagedHandle.Create());
+            var font = new ScaledFont(face, matrix, ctm, new FontOptions());
+            font.Status.Should().Be(Status.Success);
+            font.FontType.Should().NotBe(FontType.Toy); // Should be the backend type, e.g. Quartz on macOS
+
+            font.Extents(out FontExtents font_extents);
+            font_extents.Ascent.Should().Be(0);
+
+            font.TextExtents("foo", out TextExtents text_extents);
+            text_extents.Height.Should().Be(0);
+
+            font.GetFontMatrix(matrix);
+            font.GetCtm(matrix);
+            font.GetScaleMatrix(matrix);
+
+            var options = new FontOptions();
+            font.GetFontOptions(options);
+            options.Status.Should().Be(Status.Success);
+
+            font.GetFontFace().Status.Should().Be(Status.Success);
+        }
+    }
+}


### PR DESCRIPTION
This adds the bindings from https://cairographics.org/manual/cairo-cairo-scaled-font-t.html, minus the `cairo_glyph_t` methods which require bindings for additional types.