### PR TITLE
Add binding for cairo_image_surface_get_data()

### DIFF
--- a/src/Libs/cairo-1.0/Internal/ImageSurface.cs
+++ b/src/Libs/cairo-1.0/Internal/ImageSurface.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace Cairo.Internal;
 
@@ -9,6 +10,9 @@ public class ImageSurface
 
     // Skip cairo_image_surface_create_for_data for now, as it has some
     // additional lifetime requirements for the input buffer.
+
+    [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_image_surface_get_data")]
+    public static extern IntPtr GetData(SurfaceHandle handle);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_image_surface_get_format")]
     public static extern Format GetFormat(SurfaceHandle handle);

--- a/src/Libs/cairo-1.0/Public/ImageSurface.cs
+++ b/src/Libs/cairo-1.0/Public/ImageSurface.cs
@@ -1,4 +1,6 @@
-﻿namespace Cairo;
+﻿using System;
+
+namespace Cairo;
 
 public class ImageSurface : Surface
 {
@@ -11,4 +13,15 @@ public class ImageSurface : Surface
     public int Height => Internal.ImageSurface.GetHeight(Handle);
     public int Width => Internal.ImageSurface.GetWidth(Handle);
     public int Stride => Internal.ImageSurface.GetStride(Handle);
+
+    public Span<byte> GetData()
+    {
+        IntPtr data = Internal.ImageSurface.GetData(Handle);
+        int len = Stride * Height; // Stride is the number of bytes per row.
+        unsafe
+        {
+            return new Span<byte>(data.ToPointer(), len);
+        }
+    }
 }
+

--- a/src/Libs/cairo-1.0/cairo-1.0.csproj
+++ b/src/Libs/cairo-1.0/cairo-1.0.csproj
@@ -3,6 +3,7 @@
     <PackageId>GirCore.Cairo-1.0</PackageId>
     <RootNamespace>Cairo</RootNamespace>
     <Description>C# bindings for cairo.</Description>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\GLib-2.0\GLib-2.0.csproj" />

--- a/src/Tests/Libs/Cairo-1.0.Tests/ImageSurfaceTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/ImageSurfaceTest.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Cairo.Tests;
@@ -11,6 +12,10 @@ public class ImageSurfaceTest : Test
     {
         var surf = new Cairo.ImageSurface(Cairo.Format.Argb32, 800, 600);
         surf.Status.Should().Be(Status.Success);
+
+        // 4 bytes per pixel since the format is Argb32.
+        Span<byte> data = surf.GetData();
+        data.Length.Should().Be(surf.Width * surf.Height * 4);
 
         surf.Width.Should().Be(800);
         surf.Height.Should().Be(600);


### PR DESCRIPTION
This is used for low-level (via `unsafe`) modification of the image buffer

Note in GtkSharp this was called `DataPtr` because they also had a separate `Data` property that returned a `byte[]` copy (https://github.com/GtkSharp/GtkSharp/blob/develop/Source/Libs/CairoSharp/ImageSurface.cs#L85), but I think calling the property `Data` is better to match the underlying Cairo API