### PR TITLE
Fix a couple issues with string (array) parameters

### DIFF
--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/String.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/String.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Generator.Model;
 
 namespace Generator.Renderer.Public.ParameterToNativeExpressions;
@@ -10,6 +11,10 @@ internal class String : ToNativeParameterConverter
 
     public void Initialize(ParameterToNativeData parameter, IEnumerable<ParameterToNativeData> _)
     {
+        // TODO - the caller needs to pass in some kind of Span<T> as a buffer that can be filled in by the C function.
+        // These functions (e.g. g_unichar_to_utf8()) expect a minimum buffer size to be provided.
+        if (parameter.Parameter.CallerAllocates)
+            throw new NotImplementedException($"{parameter.Parameter.AnyType}: String type with caller-allocates=1 not yet supported");
 
         var prefix = parameter.Parameter.Direction == GirModel.Direction.Out
             ? "out "

--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/StringArray.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/StringArray.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Generator.Model;
 
 namespace Generator.Renderer.Public.ParameterToNativeExpressions;
@@ -10,6 +11,9 @@ internal class StringArray : ToNativeParameterConverter
 
     public void Initialize(ParameterToNativeData parameter, IEnumerable<ParameterToNativeData> _)
     {
+        if (parameter.Parameter.Direction != GirModel.Direction.In)
+            throw new NotImplementedException($"{parameter.Parameter.AnyType}: String array type with direction != in not yet supported");
+
         var arrayType = parameter.Parameter.AnyType.AsT1;
         if (parameter.Parameter.Transfer == GirModel.Transfer.None && arrayType.Length == null)
         {


### PR DESCRIPTION
This addresses a couple issues encountered with global functions (#724)

- Raise an error for out string parameters with caller-allocates=true. This occurs for `g_unichar_to_utf8()`, which expects the caller to provide a suitably sized buffer, so I don't think we can safely generate bindings automatically for functions like that

-  String arrays that are a ref/out parameter produce compile errors with the current code and require further work to support. In particular, some functions like `hb_feature_to_string()` seem to incorrectly appear with string array out parameters, but actually behave like `g_unichar_to_utf8()` above and expect a pre-allocated buffer.

- While looking into this, I noticed that string arrays should also be converted to UTF8 strings, matching regular string parameters