### PR TITLE
Fix errors with marshalling record array parameters.

### DIFF
--- a/src/Generation/Generator/Renderer/Public/Parameter/From/ArrayRecordParameter.cs
+++ b/src/Generation/Generator/Renderer/Public/Parameter/From/ArrayRecordParameter.cs
@@ -16,9 +16,7 @@ internal static class ArrayRecordParameter
     {
         var arrayType = parameter.AnyType.AsT1;
 
-        return arrayType.Length is null
-            ? Type.PointerArray
-            : ComplexType.GetFullyQualified((GirModel.Record) arrayType.AnyType.AsT0) + "[]";
+        return ComplexType.GetFullyQualified((GirModel.Record) arrayType.AnyType.AsT0) + "[]";
     }
 
     private static string GetDirection(GirModel.Parameter parameter) => parameter switch

--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/RecordArray.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/RecordArray.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using Generator.Model;
 
 namespace Generator.Renderer.Public.ParameterToNativeExpressions;
@@ -21,6 +22,13 @@ internal class RecordArray : ToNativeParameterConverter
 
         parameter.SetSignatureName(parameterName);
         parameter.SetCallName(nativeVariableName);
-        parameter.SetExpression($"var {nativeVariableName} = {parameterName}.Select(record => record.Handle.DangerousGethandle()).ToArray();");
+
+        var expression = new StringBuilder();
+        expression.Append($"var {nativeVariableName} = {parameterName}.Select(record => record.Handle.DangerousGetHandle())");
+        if (arrayType.IsZeroTerminated)
+            expression.Append(".Append(IntPtr.Zero)");
+
+        expression.Append(".ToArray();");
+        parameter.SetExpression(expression.ToString());
     }
 }

--- a/src/Generation/GirLoader/Input/ArrayType.cs
+++ b/src/Generation/GirLoader/Input/ArrayType.cs
@@ -4,11 +4,14 @@ namespace GirLoader.Input;
 
 public class ArrayType : AnyType
 {
+    [XmlAttribute("name")]
+    public string? Name { get; set; }
+
     [XmlAttribute("length")]
     public string? Length { get; set; }
 
     [XmlAttribute("zero-terminated")]
-    public bool ZeroTerminated { get; set; }
+    public string? ZeroTerminated { get; set; }
 
     [XmlAttribute("fixed-size")]
     public string? FixedSize { get; set; }

--- a/src/Generation/GirLoader/Output/TypeReferenceFactory.cs
+++ b/src/Generation/GirLoader/Output/TypeReferenceFactory.cs
@@ -52,6 +52,7 @@ internal class TypeReferenceFactory
 
         int? length = int.TryParse(anyType.Array.Length, out var l) ? l : null;
         int? fixedSize = int.TryParse(anyType.Array.FixedSize, out var f) ? f : null;
+        bool? zeroTerminated = bool.TryParse(anyType.Array.ZeroTerminated, out var b) ? b : null;
 
         arrayTypeReference = new ArrayTypeReference(
             typeReference: typeReference,
@@ -60,7 +61,11 @@ internal class TypeReferenceFactory
         {
             Length = length,
             FixedSize = fixedSize,
-            IsZeroTerminated = anyType.Array.ZeroTerminated
+            // TODO: The zero-terminated attribute is not consistently present in the gir file.
+            // If there isn't a length, fixed size, or name specified, treat as zero-terminated anyways.
+            // This can be removed if the C gir generator changes this behavior.
+            IsZeroTerminated = zeroTerminated ??
+                (length is null && fixedSize is null && anyType.Array.Name is null)
         };
 
         return true;


### PR DESCRIPTION
This occurred for `g_dbus_annotation_info_lookup()` which #724 now generates bindings for

- The public type should just be `Gio.DBusAnnotationInfo[]`, not `IntPtr[]`

- If there isn't a parameter that specifies the length, ensure that a null terminated pointer array is provided to the native function

- Fix a typo in the generated code: `DangerousGethandle` -> `DangerousGetHandle`. This code path wasn't being hit previously :)

The generated code for this function was previously:
```
public static string? DbusAnnotationInfoLookup(IntPtr[] annotations, string name)
{
    var annotationsNative = annotations.Select(record => record.Handle.DangerousGethandle()).ToArray();
    var result = Gio.Internal.Functions.DbusAnnotationInfoLookup(annotationsNative, name);

    return GLib.Internal.StringHelper.ToStringUtf8(result);
}
```
And is now:
```
public static string? DbusAnnotationInfoLookup(Gio.DBusAnnotationInfo[] annotations, string name)
{
    var annotationsNative = annotations.Select(record => record.Handle.DangerousGetHandle()).Append(IntPtr.Zero).ToArray();
    var result = Gio.Internal.Functions.DbusAnnotationInfoLookup(annotationsNative, name);

    return GLib.Internal.StringHelper.ToStringUtf8(result);
}
```