### PR TITLE
Disable enum parameters that have a pointer type but a direction of 'in'

### DIFF
--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/Enumeration.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/Enumeration.cs
@@ -14,6 +14,9 @@ internal class Enumeration : ToNativeParameterConverter
         if (parameter.Parameter.Direction != GirModel.Direction.In)
             throw new NotImplementedException($"{parameter.Parameter.AnyType}: Enumeration with direction != in not yet supported");
 
+        if (parameter.Parameter.IsPointer)
+            throw new NotImplementedException($"{parameter.Parameter.AnyType}: Enumeration pointers with direction == in not yet supported");
+
         //We don't need any conversion for enumerations
         var parameterName = Parameter.GetName(parameter.Parameter);
         parameter.SetSignatureName(parameterName);


### PR DESCRIPTION
I think this is an invalid combination in general - either it should be an inout / out parameter if the value can be modified by the native function, or otherwise it should be an array type

With #724 this occurs for two functions:
- `pango_log2vis_get_embedding_levels()`. Here the C documentation indicates that it actually behaves as an in/out parameter
- `gst_buffer_add_video_gl_texture_upload_meta()`. In this case the C API is expecting an array

As `inout` and `out` enums are not currently handled, this was similarly producing incorrect generated code.