### PR TITLE
Disable string parameters with a direction of inout

### DIFF
--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/String.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/String.cs
@@ -16,6 +16,11 @@ internal class String : ToNativeParameterConverter
         if (parameter.Parameter.CallerAllocates)
             throw new NotImplementedException($"{parameter.Parameter.AnyType}: String type with caller-allocates=1 not yet supported");
 
+        // TODO - the default marshalling for 'ref string' produces crashes for functions
+        // like pango_skip_space(), so custom marshalling may be required.
+        if (parameter.Parameter.Direction == GirModel.Direction.InOut)
+            throw new NotImplementedException($"{parameter.Parameter.AnyType}: String type with direction=inout not yet supported");
+
         var prefix = parameter.Parameter.Direction == GirModel.Direction.Out
             ? "out "
             : string.Empty;


### PR DESCRIPTION
The default marshalling produces crashes for functions like `pango_skip_space()`, so more investigation is required.

This is related to #724, where a compile error (missing 'ref' keyword) was also produced because the surrounding code only handled 'in' and 'out' strings.
So far, `inout` string parameters only occur for deprecated pango functions.