### PR TITLE
Generator: Use explicit interface implementations

### DIFF
--- a/src/Generation/Generator/Fixer/Class/InterfaceMethodsCollidingWithClassMethodsFixer.cs
+++ b/src/Generation/Generator/Fixer/Class/InterfaceMethodsCollidingWithClassMethodsFixer.cs
@@ -6,15 +6,20 @@ internal class InterfaceMethodsCollidingWithClassMethodsFixer : Fixer<GirModel.C
 {
     public void Fixup(GirModel.Class @class)
     {
-        //TODO: Replace with explicit interface implementation in case of signature collisions
-
         foreach (var method in @class.Methods)
         {
             var duplicateMethods = Model.Class.DuplicateMethods(@class, method);
             foreach (var duplicateMethod in duplicateMethods)
             {
-                Method.Disable(duplicateMethod);
-                Log.Warning($"Disabled method {duplicateMethod.Parent.Name}.{duplicateMethod.Name} for class {@class.Name} as there is a conflicting method on the class.");
+                if (duplicateMethod.Parent is GirModel.Interface)
+                {
+                    Method.SetImplementExplicitly(duplicateMethod);
+                }
+                else
+                {
+                    Method.Disable(duplicateMethod);
+                    Log.Warning($"Disabled method {duplicateMethod.Parent.Name}.{duplicateMethod.Name} for class {@class.Name} as there is a conflicting method on the class.");
+                }
             }
         }
     }

--- a/src/Generation/Generator/Fixer/Class/PropertyLikeInterfacePropertyFixer.cs
+++ b/src/Generation/Generator/Fixer/Class/PropertyLikeInterfacePropertyFixer.cs
@@ -1,4 +1,5 @@
-﻿using Generator.Model;
+﻿using System.Linq;
+using Generator.Model;
 
 namespace Generator.Fixer.Class;
 
@@ -6,19 +7,9 @@ internal class PropertyLikeInterfacePropertyFixer : Fixer<GirModel.Class>
 {
     public void Fixup(GirModel.Class @class)
     {
-        foreach (var @interface in @class.Implements)
-        {
-            foreach (var interfaceProperty in @interface.Properties)
-            {
-                foreach (var property in @class.Properties)
-                {
-                    if (Property.GetName(property) == Property.GetName(interfaceProperty))
-                    {
-                        Log.Warning($"Disabling {@class.Namespace.Name}.{@class.Name}.{Property.GetName(property)} becuase it conflcits with a property of an interface ({@interface.Namespace.Name}.{@interface.Name}.{Property.GetName(interfaceProperty)})");
-                        Property.Disable(property);
-                    }
-                }
-            }
-        }
+        foreach (var interfaceProperty in @class.Implements.SelectMany(x => x.Properties))
+            foreach (var property in @class.Properties)
+                if (Property.GetName(property) == Property.GetName(interfaceProperty))
+                    Property.SetImplementExplicitly(interfaceProperty);
     }
 }

--- a/src/Generation/Generator/Model/Method.cs
+++ b/src/Generation/Generator/Model/Method.cs
@@ -6,6 +6,7 @@ internal static partial class Method
 {
     private static readonly Dictionary<GirModel.Method, string> FixedPublicNames = new();
     private static readonly Dictionary<GirModel.Method, string> FixedInternalNames = new();
+    private static readonly HashSet<GirModel.Method> ImplementExplicitly = new();
 
     public static string GetInternalName(GirModel.Method method)
     {
@@ -29,5 +30,15 @@ internal static partial class Method
     internal static void SetPublicName(GirModel.Method method, string name)
     {
         FixedPublicNames[method] = name;
+    }
+
+    public static bool GetImplemnetExplicitly(GirModel.Method method)
+    {
+        return ImplementExplicitly.Contains(method);
+    }
+
+    internal static void SetImplementExplicitly(GirModel.Method method)
+    {
+        ImplementExplicitly.Add(method);
     }
 }

--- a/src/Generation/Generator/Model/Property.cs
+++ b/src/Generation/Generator/Model/Property.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Generator.Renderer.Internal;
 
@@ -6,6 +7,8 @@ namespace Generator.Model;
 
 internal static partial class Property
 {
+    private static readonly HashSet<GirModel.Property> ImplementExplicitly = new();
+
     public static string GetName(GirModel.Property property)
     {
         return property.Name.ToPascalCase();
@@ -124,5 +127,15 @@ internal static partial class Property
             throw new System.NotImplementedException("There is currently no concept for transfering native records (structs) into the managed world.");
 
         throw new System.Exception($"Property {complexType.Name}.{property.Name} is not supported");
+    }
+
+    public static bool GetImplemnetExplicitly(GirModel.Property property)
+    {
+        return ImplementExplicitly.Contains(property);
+    }
+
+    internal static void SetImplementExplicitly(GirModel.Property property)
+    {
+        ImplementExplicitly.Add(property);
     }
 }

--- a/src/Generation/Generator/Renderer/Public/Class/InterfaceProperties/ClassInterfacePropertiesRenderer.Accessor.cs
+++ b/src/Generation/Generator/Renderer/Public/Class/InterfaceProperties/ClassInterfacePropertiesRenderer.Accessor.cs
@@ -10,8 +10,16 @@ public static partial class ClassInterfaceProperties
         if (property is { Readable: false, Writeable: false })
             return string.Empty;
 
+        var modifier = "public ";
+        var explicitImplementation = string.Empty;
+        if (Property.GetImplemnetExplicitly(property))
+        {
+            modifier = string.Empty;
+            explicitImplementation = $"{Namespace.GetPublicName(@interface.Namespace)}.{@interface.Name}.";
+        }
+
         var builder = new StringBuilder();
-        builder.AppendLine($"public {Property.GetNullableTypeName(property)} {Property.GetName(property)}");
+        builder.AppendLine($"{modifier}{Property.GetNullableTypeName(property)} {explicitImplementation}{Property.GetName(property)}");
         builder.AppendLine("{");
 
         if (property.Readable)

--- a/src/Generation/Generator/Renderer/Public/MethodRenderer.cs
+++ b/src/Generation/Generator/Renderer/Public/MethodRenderer.cs
@@ -12,11 +12,19 @@ internal static class MethodRenderer
     {
         try
         {
+            var modifier = "public ";
+            var explicitImplementation = string.Empty;
+            if (Method.GetImplemnetExplicitly(method))
+            {
+                modifier = string.Empty;
+                explicitImplementation = $"{Namespace.GetPublicName(method.Parent.Namespace)}.{method.Parent.Name}.";
+            }
+
             var parameters = ParameterToNativeExpression.Initialize(method.Parameters);
 
             return @$"
 {VersionAttribute.Render(method.Version)}
-public {ReturnType.Render(method.ReturnType)} {Method.GetPublicName(method)}({RenderParameters(parameters)})
+{modifier}{ReturnType.Render(method.ReturnType)} {explicitImplementation}{Method.GetPublicName(method)}({RenderParameters(parameters)})
 {{
     {RenderMethodContent(parameters)}
     {RenderCallStatement(method, parameters, out var resultVariableName)}


### PR DESCRIPTION
- Avoid naming conflicts for properties. E.g. an interface can have a readonly property but a class can have the same property with read / write access.
- If there are two diffent methods with the same signature on a class / interface they could have different implementations. Using explicit interface implementations allows the user to access the implementation which is wanted.

Fixes: #740