### PR TITLE
Support using a GLib.Variant in a GObject.Value

### DIFF
--- a/src/Tests/Libs/GObject-2.0.Tests/Records/ValueTest.cs
+++ b/src/Tests/Libs/GObject-2.0.Tests/Records/ValueTest.cs
@@ -20,6 +20,14 @@ public class ValueTest : Test
         v.Extract().Should().Be(data);
     }
 
+    [TestMethod]
+    public void VariantFromDataShouldContainGivenData()
+    {
+        var variant = GLib.Variant.Create("foo");
+        var v = Value.From(variant);
+        v.Extract<GLib.Variant>().GetString().Should().Be("foo");
+    }
+
     [DataTestMethod]
     [DataRow("Hello", Internal.BasicType.String)]
     [DataRow(true, Internal.BasicType.Boolean)]

--- a/src/Tests/Libs/Gio-2.0.Tests/SimpleActionTest.cs
+++ b/src/Tests/Libs/Gio-2.0.Tests/SimpleActionTest.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Gio.Tests;
+
+[TestClass, TestCategory("SystemTest")]
+public class SimpleActionTest : Test
+{
+    [TestMethod]
+    public void TestActivate()
+    {
+        var action = SimpleAction.NewStateful("myname", GLib.VariantType.String, GLib.Variant.Create("foo"));
+
+        string result = action.GetState().GetString();
+        action.OnActivate += (_, args) =>
+        {
+            result = args.Parameter!.GetString();
+        };
+
+        action.Activate(GLib.Variant.Create("bar"));
+
+        result.Should().Be("bar");
+    }
+}


### PR DESCRIPTION
This fixes issues with e.g. accessing the GVariant parameter from the `Gio.SimpleAction::activate` [signal](https://docs.gtk.org/gio/signal.SimpleAction.activate.html), which internally requires going through a GObject.Value