### PR TITLE
Add more comprehensive support for primitive value type parameters

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/Parameter/From/PrimitiveValueTypeParameter.cs
+++ b/src/Generation/Generator/Renderer/Internal/Parameter/From/PrimitiveValueTypeParameter.cs
@@ -7,6 +7,19 @@ internal static class PrimitiveValueTypeParameter
 
     public static RenderableParameter Create(GirModel.Parameter parameter)
     {
+        // If the parameter is both nullable and optional this implies a parameter type like 'int **' and possibly
+        // ownership transfer (this combination does not currently occur for any functions).
+        if (parameter.Nullable && parameter.Optional)
+            throw new System.NotImplementedException($"{parameter.AnyType} - Primitive value type with nullable=true and optional=true not yet supported");
+
+        // Nullable-only parameters likely have incorrect annotations and should be marked optional instead.
+        if (parameter.Nullable)
+            Log.Information($"Primitive value type '{parameter.Name}' with nullable=true is likely an incorrect annotation");
+
+        // The caller-allocates flag is not meaningful for primitive types (https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/446)
+        if (parameter.CallerAllocates)
+            Log.Information($"Primitive value type '{parameter.Name}' with caller-allocates=true is an incorrect annotation");
+
         return new RenderableParameter(
             Attribute: string.Empty,
             Direction: GetDirection(parameter),
@@ -15,14 +28,17 @@ internal static class PrimitiveValueTypeParameter
         );
     }
 
-    private static string GetNullableTypeName(GirModel.Parameter parameter) => parameter.IsPointer
-        ? Type.Pointer
-        : Type.GetName(parameter.AnyType.AsT0);
+    private static string GetNullableTypeName(GirModel.Parameter parameter) => parameter switch
+    {
+        // Public bindings are not generated for pointer types with direction=in, but we can still generate the internal binding with a pointer.
+        { Direction: GirModel.Direction.In, IsPointer: true } => Type.Pointer,
+        _ => Type.GetName(parameter.AnyType.AsT0)
+    };
 
     private static string GetDirection(GirModel.Parameter parameter) => parameter switch
     {
+        // - Optional inout and out types are just exposed as non-nullable ref / out parameters which the user can ignore if desired.
         { Direction: GirModel.Direction.InOut } => ParameterDirection.Ref(),
-        { Direction: GirModel.Direction.Out, CallerAllocates: true } => ParameterDirection.Ref(),
         { Direction: GirModel.Direction.Out } => ParameterDirection.Out(),
         _ => ParameterDirection.In()
     };

--- a/src/Generation/Generator/Renderer/Public/Parameter/From/PrimitiveValueTypeParameter.cs
+++ b/src/Generation/Generator/Renderer/Public/Parameter/From/PrimitiveValueTypeParameter.cs
@@ -1,0 +1,21 @@
+﻿using Generator.Model;
+
+namespace Generator.Renderer.Public;
+
+internal static class PrimitiveValueTypeParameter
+{
+    public static ParameterTypeData Create(GirModel.Parameter parameter)
+    {
+        return new ParameterTypeData(
+            Direction: GetDirection(parameter),
+            NullableTypeName: Type.GetName(parameter.AnyType.AsT0)
+        );
+    }
+
+    public static string GetDirection(GirModel.Parameter parameter) => parameter switch
+    {
+        { Direction: GirModel.Direction.InOut } => ParameterDirection.Ref(),
+        { Direction: GirModel.Direction.Out } => ParameterDirection.Out(),
+        _ => ParameterDirection.In()
+    };
+}

--- a/src/Generation/Generator/Renderer/Public/Parameter/RenderableParameterFactory.cs
+++ b/src/Generation/Generator/Renderer/Public/Parameter/RenderableParameterFactory.cs
@@ -16,6 +16,7 @@ internal static class RenderableParameterFactory
             GirModel.Record => RecordParameter.Create(parameter),
             GirModel.Void => VoidParameter.Create(parameter),
             GirModel.Callback => CallbackParameter.Create(parameter),
+            GirModel.PrimitiveValueType => PrimitiveValueTypeParameter.Create(parameter),
             _ => StandardParameter.Create(parameter) //TODO: Remove Standard Parameter
         },
         arraytype => arraytype.AnyType.Match(

--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/PrimitiveValueType.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/PrimitiveValueType.cs
@@ -11,15 +11,18 @@ internal class PrimitiveValueType : ToNativeParameterConverter
 
     public void Initialize(ParameterToNativeData parameter, IEnumerable<ParameterToNativeData> _)
     {
-        if (parameter.Parameter.IsPointer)
-            throw new NotImplementedException($"{parameter.Parameter.AnyType}: Pointed primitive value types can not yet be converted to native");
+        // When there is a pointer type with direction=in, the native functions are often expecting
+        // the pointer to be an array, e.g. gdk_pango_layout_get_clip_region(), so in general this
+        // is not safe to generate bindings for.
+        if (parameter.Parameter.IsPointer && parameter.Parameter.Direction == GirModel.Direction.In)
+            throw new NotImplementedException($"{parameter.Parameter.AnyType}: Pointed primitive value types with direction == in can not yet be converted to native");
 
-        if (parameter.Parameter.Direction != GirModel.Direction.In)
-            throw new NotImplementedException($"{parameter.Parameter.AnyType}: Primitive value type with direction != in not yet supported");
+        // Add the direction keyword, e.g. ref or out, when calling the native function.
+        var direction = PrimitiveValueTypeParameter.GetDirection(parameter.Parameter);
 
         //We don't need any conversion for native parameters
         var parameterName = Parameter.GetName(parameter.Parameter);
         parameter.SetSignatureName(parameterName);
-        parameter.SetCallName(parameterName);
+        parameter.SetCallName(direction + parameterName);
     }
 }

--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/RecordArray.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/RecordArray.cs
@@ -17,6 +17,9 @@ internal class RecordArray : ToNativeParameterConverter
         if (!arrayType.IsPointer)
             throw new NotImplementedException($"{parameter.Parameter.AnyType}: Not pointed array record types can not yet be converted to native.");
 
+        if (parameter.Parameter.Direction == GirModel.Direction.Out)
+            throw new NotImplementedException($"{parameter.Parameter.AnyType}: Array record type with direction=out not yet supported.");
+
         var parameterName = Parameter.GetName(parameter.Parameter);
         var nativeVariableName = parameterName + "Native";
 

--- a/src/Generation/GirLoader/Input/Parameter.cs
+++ b/src/Generation/GirLoader/Input/Parameter.cs
@@ -13,6 +13,9 @@ public class Parameter : AnyType
     [XmlAttribute("direction")]
     public string? Direction { get; set; }
 
+    [XmlAttribute("optional")]
+    public bool Optional;
+
     [XmlAttribute("caller-allocates")]
     public bool CallerAllocates;
 

--- a/src/Generation/GirLoader/Output/SingleParameter.cs
+++ b/src/Generation/GirLoader/Output/SingleParameter.cs
@@ -6,19 +6,21 @@ public partial class SingleParameter : Parameter
     public Direction Direction { get; }
     public Transfer Transfer { get; }
     public bool Nullable { get; }
+    public bool Optional { get; }
     public bool CallerAllocates { get; }
     public int? ClosureIndex { get; }
     public int? DestroyIndex { get; }
     public Scope? CallbackScope { get; }
     public string Name { get; }
 
-    public SingleParameter(string name, TypeReference typeReference, Direction direction, Transfer transfer, bool nullable, bool callerAllocates, int? closureIndex, int? destroyIndex, Scope? scope)
+    public SingleParameter(string name, TypeReference typeReference, Direction direction, Transfer transfer, bool nullable, bool optional, bool callerAllocates, int? closureIndex, int? destroyIndex, Scope? scope)
     {
         Name = name;
         TypeReference = typeReference;
         Direction = direction;
         Transfer = transfer;
         Nullable = nullable;
+        Optional = optional;
         CallerAllocates = callerAllocates;
         ClosureIndex = closureIndex;
         DestroyIndex = destroyIndex;

--- a/src/Generation/GirLoader/Output/SingleParameterFactory.cs
+++ b/src/Generation/GirLoader/Output/SingleParameterFactory.cs
@@ -36,6 +36,7 @@ internal class SingleParameterFactory
             direction: DirectionFactory.Create(parameter.Direction),
             transfer: _transferFactory.FromText(parameter.TransferOwnership),
             nullable: parameter.Nullable,
+            optional: parameter.Optional,
             callerAllocates: parameter.CallerAllocates,
             closureIndex: parameter.Closure == -1 ? null : parameter.Closure,
             destroyIndex: parameter.Destroy == -1 ? null : parameter.Destroy,

--- a/src/Generation/GirModel/Parameter.cs
+++ b/src/Generation/GirModel/Parameter.cs
@@ -5,6 +5,7 @@ public interface Parameter : Nullable
     string Name { get; }
     Direction Direction { get; }
     Transfer Transfer { get; }
+    bool Optional { get; }
     bool CallerAllocates { get; }
     int? Closure { get; }
     int? Destroy { get; }

--- a/src/Libs/Gst-1.0/Public/Application.Static.cs
+++ b/src/Libs/Gst-1.0/Public/Application.Static.cs
@@ -6,7 +6,7 @@ public class Application
 {
     public static void Init()
     {
-        var argc = IntPtr.Zero;
+        int argc = 0;
         Internal.Functions.Init(ref argc, new string[0]);
     }
 }

--- a/src/Native/GirTestLib/girtest-primitive-value-type-tester.c
+++ b/src/Native/GirTestLib/girtest-primitive-value-type-tester.c
@@ -36,3 +36,53 @@ girtest_primitive_value_type_tester_int_in(int val)
 {
     return 2 * val;
 }
+
+/**
+ * girtest_primitive_value_type_tester_int_in_out:
+ * @val: (inout): An integer value to multiply by 2
+ *
+ * Simple test for an in/out integer parameter.
+ */
+void
+girtest_primitive_value_type_tester_int_in_out(int *val)
+{
+    *val *= 2;
+}
+
+/**
+ * girtest_primitive_value_type_tester_int_in_out_optional:
+ * @val: (inout) (optional): An optional integer value to multiply by 2
+ *
+ * Simple test for a optional in/out integer parameter.
+ */
+void
+girtest_primitive_value_type_tester_int_in_out_optional(int *val)
+{
+    if (val)
+        *val *= 2;
+}
+
+/**
+ * girtest_primitive_value_type_tester_int_out:
+ * @result: (out): An integer value to write to.
+ *
+ * Simple test for an out integer parameter.
+ */
+void
+girtest_primitive_value_type_tester_int_out(int *result)
+{
+    *result = 42;
+}
+
+/**
+ * girtest_primitive_value_type_tester_int_out_optional:
+ * @result: (out) (optional): An optional integer value to write to.
+ *
+ * Simple test for a optional out integer parameter.
+ */
+void
+girtest_primitive_value_type_tester_int_out_optional(int *result)
+{
+    if (result)
+        *result = 42;
+}

--- a/src/Native/GirTestLib/girtest-primitive-value-type-tester.h
+++ b/src/Native/GirTestLib/girtest-primitive-value-type-tester.h
@@ -12,5 +12,13 @@ G_DECLARE_FINAL_TYPE(GirTestPrimitiveValueTypeTester, girtest_primitive_value_ty
 int
 girtest_primitive_value_type_tester_int_in(int val);
 
+void girtest_primitive_value_type_tester_int_in_out(int *val);
+
+void girtest_primitive_value_type_tester_int_in_out_optional(int *val);
+
+void girtest_primitive_value_type_tester_int_out(int *result);
+
+void girtest_primitive_value_type_tester_int_out_optional(int *result);
+
 G_END_DECLS
 

--- a/src/Tests/Libs/GirTest-0.1.Tests/PrimitiveValueTypeTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/PrimitiveValueTypeTest.cs
@@ -11,4 +11,24 @@ public class PrimitiveValueTypeTest : Test
     {
         PrimitiveValueTypeTester.IntIn(5).Should().Be(10);
     }
+
+    [TestMethod]
+    public void InOutParameterShouldSucceed()
+    {
+        int val = 5;
+        GirTest.PrimitiveValueTypeTester.IntInOut(ref val);
+        val.Should().Be(10);
+        GirTest.PrimitiveValueTypeTester.IntInOutOptional(ref val);
+        val.Should().Be(20);
+    }
+
+    [TestMethod]
+    public void OutParameterShouldSucceed()
+    {
+        GirTest.PrimitiveValueTypeTester.IntOut(out int result);
+        result.Should().Be(42);
+
+        GirTest.PrimitiveValueTypeTester.IntOutOptional(out int result2);
+        result2.Should().Be(42);
+    }
 }


### PR DESCRIPTION
I think this covers all of the possible cases for primitive value types, with the main addition being support for functions with `inout` or `out` primitive value parameters

- Don't generate public bindings for primitive value pointer types that have a direction of `in`. Many occurrences of this in the gir files were actually treating the pointer as an array, but didn't mark it as such in the documentation (e.g. `gdk_pango_layout_get_clip_region()`), so I don't think we can safely generate public bindings for this case.

- Translate `inout` and `out` parameters to 'ref' and 'out' parameters in C#.
  - Nullable `out` parameters are just exposed as non-nullable `out` parameters in C#. In C the meaning of null is "ignore the output value", so in C# I think the idiomatic equivalent is to just have the user do `out var _` if they want to ignore it. An `out int?` parameter doesn't really make sense with what the native function is doing.
  - Nullable `inout` parameters are similarly exposed as a non-nullable `ref` parameter. I'm less sure about this - it could perhaps be a `ref int?` parameter, but this case only occurs for `gst_init()` currently.
  - The `caller-allocates` and `transfer` flags seem to be meaningless and are inconsistently used by the native functions. I didn't find any occurrences of native functions allocating or freeing a primitive value type pointer

- With these changes, `Pango.Layout.GetLogAttrs()` was now being generated but encountered a compile error with record arrays that have direction=out, since the generated code doesn't work at all in that case. This is skipped for now, to be handled with bug #763