### PR TITLE
Update manual Cairo bindings for string parameters

### DIFF
--- a/src/Libs/cairo-1.0/Internal/Context.Paths.cs
+++ b/src/Libs/cairo-1.0/Internal/Context.Paths.cs
@@ -60,5 +60,5 @@ public partial class Context
     public static extern void RelMoveTo(ContextHandle cr, double x, double y);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_text_path")]
-    public static extern void TextPath(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8);
+    public static extern void TextPath(ContextHandle cr, GLib.Internal.NonNullableUtf8StringHandle utf8);
 }

--- a/src/Libs/cairo-1.0/Internal/Context.Text.cs
+++ b/src/Libs/cairo-1.0/Internal/Context.Text.cs
@@ -21,7 +21,7 @@ public partial class Context
     public static extern ScaledFontUnownedHandle GetScaledFont(ContextHandle cr);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_select_font_face")]
-    public static extern void SelectFontFace(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string family, FontSlant slant, FontWeight weight);
+    public static extern void SelectFontFace(ContextHandle cr, GLib.Internal.NonNullableUtf8StringHandle family, FontSlant slant, FontWeight weight);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_set_font_face")]
     public static extern void SetFontFace(ContextHandle cr, FontFaceHandle font_face);
@@ -39,8 +39,8 @@ public partial class Context
     public static extern void SetScaledFont(ContextHandle cr, ScaledFontHandle scaled_font);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_show_text")]
-    public static extern void ShowText(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8);
+    public static extern void ShowText(ContextHandle cr, GLib.Internal.NonNullableUtf8StringHandle utf8);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_text_extents")]
-    public static extern void TextExtents(ContextHandle cr, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8, out TextExtents extents);
+    public static extern void TextExtents(ContextHandle cr, GLib.Internal.NonNullableUtf8StringHandle utf8, out TextExtents extents);
 }

--- a/src/Libs/cairo-1.0/Internal/FontOptions.cs
+++ b/src/Libs/cairo-1.0/Internal/FontOptions.cs
@@ -30,7 +30,7 @@ public partial class FontOptions
     public static extern SubpixelOrder GetSubpixelOrder(FontOptionsHandle handle);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_options_get_variations")]
-    public static extern IntPtr GetVariations(FontOptionsHandle handle);
+    public static extern GLib.Internal.NullableUtf8StringUnownedHandle GetVariations(FontOptionsHandle handle);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_options_hash")]
     public static extern ulong Hash(FontOptionsHandle handle);
@@ -51,7 +51,7 @@ public partial class FontOptions
     public static extern void SetSubpixelOrder(FontOptionsHandle handle, SubpixelOrder subpixelOrder);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_options_set_variations")]
-    public static extern void SetVariations(FontOptionsHandle handle, [MarshalAs(UnmanagedType.LPUTF8Str)] string variations);
+    public static extern void SetVariations(FontOptionsHandle handle, GLib.Internal.NullableUtf8StringHandle variations);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_font_options_status")]
     public static extern Status Status(FontOptionsHandle handle);

--- a/src/Libs/cairo-1.0/Internal/ScaledFont.cs
+++ b/src/Libs/cairo-1.0/Internal/ScaledFont.cs
@@ -36,5 +36,5 @@ public partial class ScaledFont
     public static extern Status Status(ScaledFontHandle handle);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_scaled_font_text_extents")]
-    public static extern void TextExtents(ScaledFontHandle handle, [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8, out TextExtents extents);
+    public static extern void TextExtents(ScaledFontHandle handle, GLib.Internal.NonNullableUtf8StringHandle utf8, out TextExtents extents);
 }

--- a/src/Libs/cairo-1.0/Internal/ToyFontFace.cs
+++ b/src/Libs/cairo-1.0/Internal/ToyFontFace.cs
@@ -6,10 +6,10 @@ namespace Cairo.Internal;
 public class ToyFontFace
 {
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_toy_font_face_create")]
-    public static extern FontFaceOwnedHandle Create([MarshalAs(UnmanagedType.LPUTF8Str)] string family, FontSlant slant, FontWeight weight);
+    public static extern FontFaceOwnedHandle Create(GLib.Internal.NonNullableUtf8StringHandle family, FontSlant slant, FontWeight weight);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_toy_font_face_get_family")]
-    public static extern IntPtr GetFamily(FontFaceHandle handle);
+    public static extern GLib.Internal.NonNullableUtf8StringUnownedHandle GetFamily(FontFaceHandle handle);
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_toy_font_face_get_slant")]
     public static extern FontSlant GetSlant(FontFaceHandle handle);

--- a/src/Libs/cairo-1.0/Public/Context.Paths.cs
+++ b/src/Libs/cairo-1.0/Public/Context.Paths.cs
@@ -48,7 +48,7 @@ public partial class Context
         => Internal.Context.Rectangle(Handle, x, y, width, height);
 
     public void TextPath(string text)
-        => Internal.Context.TextPath(Handle, text);
+        => Internal.Context.TextPath(Handle, GLib.Internal.NonNullableUtf8StringOwnedHandle.Create(text));
 
     public void RelCurveTo(double x1, double y1, double x2, double y2, double x3, double y3)
         => Internal.Context.RelCurveTo(Handle, x1, y1, x2, y2, x3, y3);

--- a/src/Libs/cairo-1.0/Public/Context.Text.cs
+++ b/src/Libs/cairo-1.0/Public/Context.Text.cs
@@ -8,7 +8,7 @@ public partial class Context
     // - cairo_glyph_extents()
 
     public void SelectFontFace(string family, FontSlant slant, FontWeight weight)
-        => Internal.Context.SelectFontFace(Handle, family, slant, weight);
+        => Internal.Context.SelectFontFace(Handle, GLib.Internal.NonNullableUtf8StringOwnedHandle.Create(family), slant, weight);
 
     public void SetFontSize(double size)
         => Internal.Context.SetFontSize(Handle, size);
@@ -38,11 +38,11 @@ public partial class Context
         => new ScaledFont(Internal.Context.GetScaledFont(Handle));
 
     public void ShowText(string text)
-        => Internal.Context.ShowText(Handle, text);
+        => Internal.Context.ShowText(Handle, GLib.Internal.NonNullableUtf8StringOwnedHandle.Create(text));
 
     public void FontExtents(out FontExtents extents)
         => Internal.Context.FontExtents(Handle, out extents);
 
     public void TextExtents(string text, out TextExtents extents)
-        => Internal.Context.TextExtents(Handle, text, out extents);
+        => Internal.Context.TextExtents(Handle, GLib.Internal.NonNullableUtf8StringOwnedHandle.Create(text), out extents);
 }

--- a/src/Libs/cairo-1.0/Public/FontOptions.cs
+++ b/src/Libs/cairo-1.0/Public/FontOptions.cs
@@ -49,14 +49,9 @@ public partial class FontOptions : IEquatable<FontOptions>
         set => Internal.FontOptions.SetSubpixelOrder(Handle, value);
     }
 
-    public string Variations
+    public string? Variations
     {
-        get
-        {
-            var result = Internal.FontOptions.GetVariations(Handle);
-            return GLib.Internal.StringHelper.ToStringUtf8(result);
-        }
-
-        set => Internal.FontOptions.SetVariations(Handle, value);
+        get => Internal.FontOptions.GetVariations(Handle).ConvertToString();
+        set => Internal.FontOptions.SetVariations(Handle, GLib.Internal.NullableUtf8StringOwnedHandle.Create(value));
     }
 }

--- a/src/Libs/cairo-1.0/Public/ScaledFont.cs
+++ b/src/Libs/cairo-1.0/Public/ScaledFont.cs
@@ -21,7 +21,7 @@ public partial class ScaledFont
         => Internal.ScaledFont.Extents(Handle, out extents);
 
     public void TextExtents(string text, out TextExtents extents)
-        => Internal.ScaledFont.TextExtents(Handle, text, out extents);
+        => Internal.ScaledFont.TextExtents(Handle, GLib.Internal.NonNullableUtf8StringOwnedHandle.Create(text), out extents);
 
     public FontFace GetFontFace()
         => new FontFace(Internal.ScaledFont.GetFontFace(Handle));

--- a/src/Libs/cairo-1.0/Public/ToyFontFace.cs
+++ b/src/Libs/cairo-1.0/Public/ToyFontFace.cs
@@ -5,12 +5,11 @@ namespace Cairo;
 public class ToyFontFace : FontFace
 {
     public ToyFontFace(string family, FontSlant slant, FontWeight weight)
-        : base(Internal.ToyFontFace.Create(family, slant, weight))
+        : base(Internal.ToyFontFace.Create(GLib.Internal.NonNullableUtf8StringOwnedHandle.Create(family), slant, weight))
     {
     }
 
-    public string Family
-        => GLib.Internal.StringHelper.ToStringUtf8(Internal.ToyFontFace.GetFamily(Handle));
+    public string Family => Internal.ToyFontFace.GetFamily(Handle).ConvertToString();
 
     public FontSlant Slant => Internal.ToyFontFace.GetSlant(Handle);
 

--- a/src/Tests/Libs/Cairo-1.0.Tests/FontOptionsTest.cs
+++ b/src/Tests/Libs/Cairo-1.0.Tests/FontOptionsTest.cs
@@ -24,6 +24,8 @@ public class FontOptionsTest : Test
         opts.SubpixelOrder = SubpixelOrder.Vrgb;
         opts.SubpixelOrder.Should().Be(SubpixelOrder.Vrgb);
 
+        opts.Variations = null;
+        opts.Variations.Should().BeNull();
         opts.Variations = "foo";
         opts.Variations.Should().Be("foo");
 


### PR DESCRIPTION
This is largely just a refactoring to make the manual bindings consistent with the generated bindings after #803, using the new string handle classes

For string return values this adds some more type safety over IntPtr, and fixes a couple nullable warnings from the usage of `StringHelper.ToStringUtf8()`. `FontOptions.Variations` should have actually been a nullable string, while `ToyFontFace.Family` is correct to be a non-nullable string.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
