### PR TITLE
Support string parameters with direction=out

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/Parameter/From/StringParameter.cs
+++ b/src/Generation/Generator/Renderer/Internal/Parameter/From/StringParameter.cs
@@ -1,4 +1,5 @@
-﻿using Generator.Model;
+﻿using System;
+using Generator.Model;
 
 namespace Generator.Renderer.Internal;
 
@@ -16,11 +17,20 @@ internal static class StringParameterFactory
 
     private static string GetNullableTypeName(GirModel.Parameter parameter) => parameter switch
     {
-        // TODO the type name should depend on the transfer / direction / caller-allocates flags.
-        { AnyType.AsT0: GirModel.PlatformString, Nullable: true } => PlatformString.GetInternalNullableHandleName(),
-        { AnyType.AsT0: GirModel.PlatformString, Nullable: false } => PlatformString.GetInternalNonNullableHandleName(),
-        { AnyType.AsT0: GirModel.Utf8String, Nullable: true } => Utf8String.GetInternalNullableHandleName(),
-        _ => Utf8String.GetInternalNonNullableHandleName(),
+        // Note: optional parameters are generated as regular out parameters, which the caller can ignore with 'out var _' if desired.
+        { AnyType.AsT0: GirModel.PlatformString, Nullable: true, Direction: GirModel.Direction.In } => PlatformString.GetInternalNullableHandleName(),
+        { AnyType.AsT0: GirModel.PlatformString, Nullable: false, Direction: GirModel.Direction.In } => PlatformString.GetInternalNonNullableHandleName(),
+        { AnyType.AsT0: GirModel.PlatformString, Nullable: true, Transfer: GirModel.Transfer.Full } => PlatformString.GetInternalNullableOwnedHandleName(),
+        { AnyType.AsT0: GirModel.PlatformString, Nullable: true, Transfer: GirModel.Transfer.None } => PlatformString.GetInternalNullableUnownedHandleName(),
+        { AnyType.AsT0: GirModel.PlatformString, Nullable: false, Transfer: GirModel.Transfer.Full } => PlatformString.GetInternalNonNullableOwnedHandleName(),
+        { AnyType.AsT0: GirModel.PlatformString, Nullable: false, Transfer: GirModel.Transfer.None } => PlatformString.GetInternalNonNullableUnownedHandleName(),
+        { AnyType.AsT0: GirModel.Utf8String, Nullable: true, Direction: GirModel.Direction.In } => Utf8String.GetInternalNullableHandleName(),
+        { AnyType.AsT0: GirModel.Utf8String, Nullable: false, Direction: GirModel.Direction.In } => Utf8String.GetInternalNonNullableHandleName(),
+        { AnyType.AsT0: GirModel.Utf8String, Nullable: true, Transfer: GirModel.Transfer.Full } => Utf8String.GetInternalNullableOwnedHandleName(),
+        { AnyType.AsT0: GirModel.Utf8String, Nullable: true, Transfer: GirModel.Transfer.None } => Utf8String.GetInternalNullableUnownedHandleName(),
+        { AnyType.AsT0: GirModel.Utf8String, Nullable: false, Transfer: GirModel.Transfer.Full } => Utf8String.GetInternalNonNullableOwnedHandleName(),
+        { AnyType.AsT0: GirModel.Utf8String, Nullable: false, Transfer: GirModel.Transfer.None } => Utf8String.GetInternalNonNullableUnownedHandleName(),
+        _ => throw new NotImplementedException($"{parameter.Name}: Unknown string parameter type")
     };
 
     private static string GetDirection(GirModel.Parameter parameter) => parameter switch

--- a/src/Generation/Generator/Renderer/Public/FunctionRenderer.cs
+++ b/src/Generation/Generator/Renderer/Public/FunctionRenderer.cs
@@ -20,6 +20,7 @@ public static {ReturnType.Render(function.ReturnType)} {Function.GetName(functio
 {{
     {RenderFunctionContent(parameters)}
     {RenderCallStatement(function, parameters, out var resultVariableName)}
+    {RenderPostCallContent(parameters)}
     {RenderReturnStatement(function, resultVariableName)}
 }}";
         }
@@ -40,6 +41,15 @@ public static {ReturnType.Render(function.ReturnType)} {Function.GetName(functio
     {
         return parameters
             .Select(x => x.GetExpression())
+            .Where(x => !string.IsNullOrEmpty(x))
+            .Cast<string>()
+            .Join(Environment.NewLine);
+    }
+
+    private static string RenderPostCallContent(IEnumerable<ParameterToNativeData> parameters)
+    {
+        return parameters
+            .Select(x => x.GetPostCallExpression())
             .Where(x => !string.IsNullOrEmpty(x))
             .Cast<string>()
             .Join(Environment.NewLine);

--- a/src/Generation/Generator/Renderer/Public/MethodRenderer.cs
+++ b/src/Generation/Generator/Renderer/Public/MethodRenderer.cs
@@ -28,6 +28,7 @@ internal static class MethodRenderer
 {{
     {RenderMethodContent(parameters)}
     {RenderCallStatement(method, parameters, out var resultVariableName)}
+    {RenderPostCallContent(parameters)}
     {RenderReturnStatement(method, resultVariableName)}
 }}";
         }
@@ -48,6 +49,15 @@ internal static class MethodRenderer
     {
         return parameters
             .Select(x => x.GetExpression())
+            .Where(x => !string.IsNullOrEmpty(x))
+            .Cast<string>()
+            .Join(Environment.NewLine);
+    }
+
+    private static string RenderPostCallContent(IEnumerable<ParameterToNativeData> parameters)
+    {
+        return parameters
+            .Select(x => x.GetPostCallExpression())
             .Where(x => !string.IsNullOrEmpty(x))
             .Cast<string>()
             .Join(Environment.NewLine);

--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/PlatformString.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/PlatformString.cs
@@ -16,25 +16,32 @@ internal class PlatformString : ToNativeParameterConverter
         if (parameter.Parameter.CallerAllocates)
             throw new NotImplementedException($"{parameter.Parameter.AnyType}: String type with caller-allocates=1 not yet supported");
 
-        // TODO - the default marshalling for 'ref string' produces crashes for functions
-        // like pango_skip_space(), so custom marshalling may be required.
+        // inout string parameters only occur for deprecated functions like pango_skip_space(), which may have incorrect ownership transfer annotations.
+        // These functions just update the char** parameter to point at a different location in the provided char*, but have transfer=full and caller-allocates=0
         if (parameter.Parameter.Direction == GirModel.Direction.InOut)
             throw new NotImplementedException($"{parameter.Parameter.AnyType}: String type with direction=inout not yet supported");
-
-        // TODO - support output strings
-        if (parameter.Parameter.Direction == GirModel.Direction.Out)
-            throw new NotImplementedException($"{parameter.Parameter.AnyType}: String type with direction=out not yet supported");
 
         var parameterName = Parameter.GetName(parameter.Parameter);
         parameter.SetSignatureName(parameterName);
 
         string nativeVariableName = Parameter.GetConvertedName(parameter.Parameter);
 
-        string ownedHandleTypeName = parameter.Parameter.Nullable
-            ? Model.PlatformString.GetInternalNullableOwnedHandleName()
-            : Model.PlatformString.GetInternalNonNullableOwnedHandleName();
+        if (parameter.Parameter.Direction == GirModel.Direction.Out)
+        {
+            // Note: optional parameters are generated as regular out parameters, which the caller can ignore with 'out var _' if desired.
+            parameter.SetCallName($"out var {nativeVariableName}");
 
-        parameter.SetExpression($"var {nativeVariableName} = {ownedHandleTypeName}.Create({parameterName});");
-        parameter.SetCallName(nativeVariableName);
+            // After the call, convert the resulting handle to a managed string.
+            parameter.SetPostCallExpression($"{parameterName} = {nativeVariableName}.ConvertToString();");
+        }
+        else
+        {
+            string ownedHandleTypeName = parameter.Parameter.Nullable
+                ? Model.PlatformString.GetInternalNullableOwnedHandleName()
+                : Model.PlatformString.GetInternalNonNullableOwnedHandleName();
+
+            parameter.SetExpression($"var {nativeVariableName} = {ownedHandleTypeName}.Create({parameterName});");
+            parameter.SetCallName(nativeVariableName);
+        }
     }
 }

--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/Utf8String.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/Utf8String.cs
@@ -16,25 +16,32 @@ internal class Utf8String : ToNativeParameterConverter
         if (parameter.Parameter.CallerAllocates)
             throw new NotImplementedException($"{parameter.Parameter.AnyType}: String type with caller-allocates=1 not yet supported");
 
-        // TODO - the default marshalling for 'ref string' produces crashes for functions
-        // like pango_skip_space(), so custom marshalling may be required.
+        // inout string parameters only occur for deprecated functions like pango_skip_space(), which may have incorrect ownership transfer annotations.
+        // These functions just update the char** parameter to point at a different location in the provided char*, but have transfer=full and caller-allocates=0
         if (parameter.Parameter.Direction == GirModel.Direction.InOut)
             throw new NotImplementedException($"{parameter.Parameter.AnyType}: String type with direction=inout not yet supported");
-
-        // TODO - support output strings
-        if (parameter.Parameter.Direction == GirModel.Direction.Out)
-            throw new NotImplementedException($"{parameter.Parameter.AnyType}: String type with direction=out not yet supported");
 
         var parameterName = Parameter.GetName(parameter.Parameter);
         parameter.SetSignatureName(parameterName);
 
         string nativeVariableName = Parameter.GetConvertedName(parameter.Parameter);
 
-        string ownedHandleTypeName = parameter.Parameter.Nullable
-            ? Model.Utf8String.GetInternalNullableOwnedHandleName()
-            : Model.Utf8String.GetInternalNonNullableOwnedHandleName();
+        if (parameter.Parameter.Direction == GirModel.Direction.Out)
+        {
+            // Note: optional parameters are generated as regular out parameters, which the caller can ignore with 'out var _' if desired.
+            parameter.SetCallName($"out var {nativeVariableName}");
 
-        parameter.SetExpression($"var {nativeVariableName} = {ownedHandleTypeName}.Create({parameterName});");
-        parameter.SetCallName(nativeVariableName);
+            // After the call, convert the resulting handle to a managed string.
+            parameter.SetPostCallExpression($"{parameterName} = {nativeVariableName}.ConvertToString();");
+        }
+        else
+        {
+            string ownedHandleTypeName = parameter.Parameter.Nullable
+                ? Model.Utf8String.GetInternalNullableOwnedHandleName()
+                : Model.Utf8String.GetInternalNonNullableOwnedHandleName();
+
+            parameter.SetExpression($"var {nativeVariableName} = {ownedHandleTypeName}.Create({parameterName});");
+            parameter.SetCallName(nativeVariableName);
+        }
     }
 }

--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/Utf8String.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/Utf8String.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using Generator.Model;
 
 namespace Generator.Renderer.Public.ParameterToNativeExpressions;
@@ -31,8 +32,11 @@ internal class Utf8String : ToNativeParameterConverter
             // Note: optional parameters are generated as regular out parameters, which the caller can ignore with 'out var _' if desired.
             parameter.SetCallName($"out var {nativeVariableName}");
 
-            // After the call, convert the resulting handle to a managed string.
-            parameter.SetPostCallExpression($"{parameterName} = {nativeVariableName}.ConvertToString();");
+            // After the call, convert the resulting handle to a managed string and free the native memory right away.
+            var expression = new StringBuilder();
+            expression.AppendLine($"{parameterName} = {nativeVariableName}.ConvertToString();");
+            expression.Append($"{nativeVariableName}.Dispose();");
+            parameter.SetPostCallExpression(expression.ToString());
         }
         else
         {
@@ -40,7 +44,7 @@ internal class Utf8String : ToNativeParameterConverter
                 ? Model.Utf8String.GetInternalNullableOwnedHandleName()
                 : Model.Utf8String.GetInternalNonNullableOwnedHandleName();
 
-            parameter.SetExpression($"var {nativeVariableName} = {ownedHandleTypeName}.Create({parameterName});");
+            parameter.SetExpression($"using var {nativeVariableName} = {ownedHandleTypeName}.Create({parameterName});");
             parameter.SetCallName(nativeVariableName);
         }
     }

--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/ParameterToNativeData.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/ParameterToNativeData.cs
@@ -8,6 +8,7 @@ public class ParameterToNativeData
     private string? _callName;
     private string? _signatureName;
     private string? _expression;
+    private string? _postCallExpression;
 
     public Parameter Parameter { get; }
 
@@ -27,6 +28,13 @@ public class ParameterToNativeData
     }
 
     public string? GetExpression() => _expression;
+
+    public void SetPostCallExpression(string expression)
+    {
+        _postCallExpression = expression;
+    }
+
+    public string? GetPostCallExpression() => _postCallExpression;
 
     public void SetCallName(string name)
     {

--- a/src/Native/GirTestLib/girtest-string-tester.c
+++ b/src/Native/GirTestLib/girtest-string-tester.c
@@ -250,3 +250,235 @@ girtest_string_tester_filename_return_unexpected_null()
 {
     return NULL;
 }
+
+/**
+ * girtest_string_tester_utf8_out_transfer_none:
+ * @s: (in): Pointer to the start of a UTF-8 encoded string.
+ * @result: (out) (transfer none): A reference to the input string, with no ownership.
+ *
+ * Test for a UTF-8 string output value with no ownership transfer.
+ */
+void
+girtest_string_tester_utf8_out_transfer_none(const gchar *s, const gchar **result)
+{
+    g_assert_nonnull(s);
+    g_assert_nonnull(result);
+    *result = s;
+}
+
+/**
+ * girtest_string_tester_utf8_out_optional_transfer_none:
+ * @s: (in): Pointer to the start of a UTF-8 encoded string.
+ * @result: (out) (optional) (transfer none): A reference to the input string, with no ownership.
+ *
+ * Test for an optional UTF-8 string output value with no ownership transfer.
+ */
+void
+girtest_string_tester_utf8_out_optional_transfer_none(const gchar *s, const gchar **result)
+{
+    g_assert_nonnull(s);
+    if (result)
+        *result = s;
+}
+
+/**
+ * girtest_string_tester_utf8_out_nullable_transfer_none:
+ * @s: (in) (nullable): Pointer to the start of a UTF-8 encoded string, or NULL.
+ * @result: (out) (nullable) (transfer none): A reference to the input string, with no ownership.
+ *
+ * Test for a nullable UTF-8 string output value with no ownership transfer.
+ */
+void
+girtest_string_tester_utf8_out_nullable_transfer_none(const gchar *s, const gchar **result)
+{
+    g_assert_nonnull(result);
+    *result = s;
+}
+
+/**
+ * girtest_string_tester_utf8_out_nullable_optional_transfer_none:
+ * @s: (in) (nullable): Pointer to the start of a UTF-8 encoded string, or NULL.
+ * @result: (out) (optional) (nullable) (transfer none): A reference to the input string, with no ownership.
+ *
+ * Test for an optional and nullable UTF-8 string output value with no ownership transfer.
+ */
+void
+girtest_string_tester_utf8_out_nullable_optional_transfer_none(const gchar *s, const gchar **result)
+{
+    if (result)
+        *result = s;
+}
+
+/**
+ * girtest_string_tester_utf8_out_transfer_full:
+ * @s: (in): Pointer to the start of a UTF-8 encoded string.
+ * @result: (out) (transfer full): A copy of the input string.
+ *
+ * Test for a UTF-8 string output value with full ownership transfer.
+ */
+void
+girtest_string_tester_utf8_out_transfer_full(const gchar *s, gchar **result)
+{
+    g_assert_nonnull(s);
+    g_assert_nonnull(result);
+    *result = g_strdup(s);
+}
+
+/**
+ * girtest_string_tester_utf8_out_optional_transfer_full:
+ * @s: (in): Pointer to the start of a UTF-8 encoded string.
+ * @result: (out) (optional) (transfer full): A copy of the input string.
+ *
+ * Test for an optional UTF-8 string output value with full ownership transfer.
+ */
+void
+girtest_string_tester_utf8_out_optional_transfer_full(const gchar *s, gchar **result)
+{
+    g_assert_nonnull(s);
+    if (result)
+        *result = g_strdup(s);
+}
+
+/**
+ * girtest_string_tester_utf8_out_nullable_transfer_full:
+ * @s: (in) (nullable): Pointer to the start of a UTF-8 encoded string, or NULL.
+ * @result: (out) (nullable) (transfer full): A copy of the input string.
+ *
+ * Test for a nullable UTF-8 string output value with full ownership transfer.
+ */
+void
+girtest_string_tester_utf8_out_nullable_transfer_full(const gchar *s, gchar **result)
+{
+    g_assert_nonnull(result);
+    *result = s ? g_strdup(s) : NULL;
+}
+
+/**
+ * girtest_string_tester_utf8_out_nullable_optional_transfer_full:
+ * @s: (in) (nullable): Pointer to the start of a UTF-8 encoded string, or NULL.
+ * @result: (out) (optional) (nullable) (transfer full): A copy of the input string.
+ *
+ * Test for a optional and nullable UTF-8 string output value with full ownership transfer.
+ */
+void
+girtest_string_tester_utf8_out_nullable_optional_transfer_full(const gchar *s, gchar **result)
+{
+    if (result)
+        *result = s ? g_strdup(s) : NULL;
+}
+
+/**
+ * girtest_string_tester_filename_out_transfer_none:
+ * @s: (in) (type filename): Pointer to the start of a filename encoded string.
+ * @result: (out) (type filename) (transfer none): A reference to the input string, with no ownership.
+ *
+ * Test for a filename string output value with no ownership transfer.
+ */
+void
+girtest_string_tester_filename_out_transfer_none(const gchar *s, const gchar **result)
+{
+    g_assert_nonnull(s);
+    g_assert_nonnull(result);
+    *result = s;
+}
+
+/**
+ * girtest_string_tester_filename_out_optional_transfer_none:
+ * @s: (in) (type filename): Pointer to the start of a filename encoded string.
+ * @result: (out) (type filename) (optional) (transfer none): A reference to the input string, with no ownership.
+ *
+ * Test for an optional filename string output value with no ownership transfer.
+ */
+void
+girtest_string_tester_filename_out_optional_transfer_none(const gchar *s, const gchar **result)
+{
+    g_assert_nonnull(s);
+    if (result)
+        *result = s;
+}
+
+/**
+ * girtest_string_tester_filename_out_nullable_transfer_none:
+ * @s: (in) (type filename) (nullable): Pointer to the start of a filename encoded string, or NULL.
+ * @result: (out) (type filename) (nullable) (transfer none): A reference to the input string, with no ownership.
+ *
+ * Test for a nullable filename string output value with no ownership transfer.
+ */
+void
+girtest_string_tester_filename_out_nullable_transfer_none(const gchar *s, const gchar **result)
+{
+    g_assert_nonnull(result);
+    *result = s;
+}
+
+/**
+ * girtest_string_tester_filename_out_nullable_optional_transfer_none:
+ * @s: (in) (type filename) (nullable): Pointer to the start of a filename encoded string, or NULL.
+ * @result: (out) (type filename) (optional) (nullable) (transfer none): A reference to the input string, with no ownership.
+ *
+ * Test for an optional and nullable filename string output value with no ownership transfer.
+ */
+void
+girtest_string_tester_filename_out_nullable_optional_transfer_none(const gchar *s, const gchar **result)
+{
+    if (result)
+        *result = s;
+}
+
+/**
+ * girtest_string_tester_filename_out_transfer_full:
+ * @s: (in) (type filename): Pointer to the start of a filename encoded string.
+ * @result: (out) (type filename) (transfer full): A copy of the input string.
+ *
+ * Test for a filename string output value with full ownership transfer.
+ */
+void
+girtest_string_tester_filename_out_transfer_full(const gchar *s, gchar **result)
+{
+    g_assert_nonnull(s);
+    g_assert_nonnull(result);
+    *result = g_strdup(s);
+}
+
+/**
+ * girtest_string_tester_filename_out_optional_transfer_full:
+ * @s: (in) (type filename): Pointer to the start of a filename encoded string.
+ * @result: (out) (type filename) (optional) (transfer full): A copy of the input string.
+ *
+ * Test for an optional filename string output value with full ownership transfer.
+ */
+void
+girtest_string_tester_filename_out_optional_transfer_full(const gchar *s, gchar **result)
+{
+    g_assert_nonnull(s);
+    if (result)
+        *result = g_strdup(s);
+}
+
+/**
+ * girtest_string_tester_filename_out_nullable_transfer_full:
+ * @s: (in) (type filename) (nullable): Pointer to the start of a filename encoded string, or NULL.
+ * @result: (out) (type filename) (nullable) (transfer full): A copy of the input string.
+ *
+ * Test for a nullable filename string output value with full ownership transfer.
+ */
+void
+girtest_string_tester_filename_out_nullable_transfer_full(const gchar *s, gchar **result)
+{
+    g_assert_nonnull(result);
+    *result = s ? g_strdup(s) : NULL;
+}
+
+/**
+ * girtest_string_tester_filename_out_nullable_optional_transfer_full:
+ * @s: (in) (type filename) (nullable): Pointer to the start of a filename encoded string, or NULL.
+ * @result: (out) (type filename) (optional) (nullable) (transfer full): A copy of the input string.
+ *
+ * Test for a optional and nullable filename string output value with full ownership transfer.
+ */
+void
+girtest_string_tester_filename_out_nullable_optional_transfer_full(const gchar *s, gchar **result)
+{
+    if (result)
+        *result = s ? g_strdup(s) : NULL;
+}

--- a/src/Native/GirTestLib/girtest-string-tester.h
+++ b/src/Native/GirTestLib/girtest-string-tester.h
@@ -56,5 +56,53 @@ girtest_string_tester_utf8_return_unexpected_null();
 gchar *
 girtest_string_tester_filename_return_unexpected_null();
 
+void
+girtest_string_tester_utf8_out_transfer_none(const gchar *s, const gchar **result);
+
+void
+girtest_string_tester_utf8_out_optional_transfer_none(const gchar *s, const gchar **result);
+
+void
+girtest_string_tester_utf8_out_nullable_transfer_none(const gchar *s, const gchar **result);
+
+void
+girtest_string_tester_utf8_out_nullable_optional_transfer_none(const gchar *s, const gchar **result);
+
+void
+girtest_string_tester_utf8_out_transfer_full(const gchar *s, gchar **result);
+
+void
+girtest_string_tester_utf8_out_optional_transfer_full(const gchar *s, gchar **result);
+
+void
+girtest_string_tester_utf8_out_nullable_transfer_full(const gchar *s, gchar **result);
+
+void
+girtest_string_tester_utf8_out_nullable_optional_transfer_full(const gchar *s, gchar **result);
+
+void
+girtest_string_tester_filename_out_transfer_none(const gchar *s, const gchar **result);
+
+void
+girtest_string_tester_filename_out_optional_transfer_none(const gchar *s, const gchar **result);
+
+void
+girtest_string_tester_filename_out_nullable_transfer_none(const gchar *s, const gchar **result);
+
+void
+girtest_string_tester_filename_out_nullable_optional_transfer_none(const gchar *s, const gchar **result);
+
+void
+girtest_string_tester_filename_out_transfer_full(const gchar *s, gchar **result);
+
+void
+girtest_string_tester_filename_out_optional_transfer_full(const gchar *s, gchar **result);
+
+void
+girtest_string_tester_filename_out_nullable_transfer_full(const gchar *s, gchar **result);
+
+void
+girtest_string_tester_filename_out_nullable_optional_transfer_full(const gchar *s, gchar **result);
+
 G_END_DECLS
 

--- a/src/Tests/Libs/GirTest-0.1.Tests/StringTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/StringTest.cs
@@ -74,4 +74,84 @@ public class StringTest : Test
         Action act = () => StringTester.FilenameReturnUnexpectedNull();
         act.Should().Throw<GLib.Internal.NullHandleException>();
     }
+
+    [TestMethod]
+    public void OutUtf8ParameterShouldSucceed()
+    {
+        StringTester.Utf8OutTransferNone(TestString, out string result);
+        result.Should().Be(TestString);
+
+        StringTester.Utf8OutOptionalTransferNone(TestString, out string result2);
+        result2.Should().Be(TestString);
+
+        StringTester.Utf8OutTransferFull(TestString, out string result3);
+        result3.Should().Be(TestString);
+
+        StringTester.Utf8OutOptionalTransferFull(TestString, out string result4);
+        result4.Should().Be(TestString);
+
+        StringTester.Utf8OutNullableTransferNone(TestString, out string? result5);
+        result5.Should().Be(TestString);
+
+        StringTester.Utf8OutNullableTransferNone(null, out string? result6);
+        result6.Should().BeNull();
+
+        StringTester.Utf8OutNullableOptionalTransferNone(TestString, out string? result7);
+        result7.Should().Be(TestString);
+
+        StringTester.Utf8OutNullableOptionalTransferNone(null, out string? result8);
+        result8.Should().BeNull();
+
+        StringTester.Utf8OutNullableTransferFull(TestString, out string? result9);
+        result9.Should().Be(TestString);
+
+        StringTester.Utf8OutNullableTransferFull(null, out string? result10);
+        result10.Should().BeNull();
+
+        StringTester.Utf8OutNullableOptionalTransferFull(TestString, out string? result11);
+        result11.Should().Be(TestString);
+
+        StringTester.Utf8OutNullableOptionalTransferFull(null, out string? result12);
+        result12.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void OutFilenameParameterShouldSucceed()
+    {
+        StringTester.FilenameOutTransferNone(TestString, out string result);
+        result.Should().Be(TestString);
+
+        StringTester.FilenameOutOptionalTransferNone(TestString, out string result2);
+        result2.Should().Be(TestString);
+
+        StringTester.FilenameOutTransferFull(TestString, out string result3);
+        result3.Should().Be(TestString);
+
+        StringTester.FilenameOutOptionalTransferFull(TestString, out string result4);
+        result4.Should().Be(TestString);
+
+        StringTester.FilenameOutNullableTransferNone(TestString, out string? result5);
+        result5.Should().Be(TestString);
+
+        StringTester.FilenameOutNullableTransferNone(null, out string? result6);
+        result6.Should().BeNull();
+
+        StringTester.FilenameOutNullableOptionalTransferNone(TestString, out string? result7);
+        result7.Should().Be(TestString);
+
+        StringTester.FilenameOutNullableOptionalTransferNone(null, out string? result8);
+        result8.Should().BeNull();
+
+        StringTester.FilenameOutNullableTransferFull(TestString, out string? result9);
+        result9.Should().Be(TestString);
+
+        StringTester.FilenameOutNullableTransferFull(null, out string? result10);
+        result10.Should().BeNull();
+
+        StringTester.FilenameOutNullableOptionalTransferFull(TestString, out string? result11);
+        result11.Should().Be(TestString);
+
+        StringTester.FilenameOutNullableOptionalTransferFull(null, out string? result12);
+        result12.Should().BeNull();
+    }
 }


### PR DESCRIPTION
- The internal functions have a signature such as `out NonNullablePlatformStringUnownedHandle`, corresponding to the native signatures like `const gchar **`

- Introduce a "post-call" expression for parameters, which is used to take the resulting string handle and assign `handle.ConvertToString()` to the original `out string` parameter

- As with primitive value types, optional parameters are just generated as a normal `out` parameter that the caller can ignore with `out var _` if desired

- A direction of inout, or caller-allocates=1, is still not supported due to the issues noted in `ParameterToNativeExpression/Converter/Utf8String.cs`. These are low priority since inout string parameters only occur for deprecated functions, and `g_unichar_to_utf8` is the only function with caller-allocates=1

Bug: #791

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
