### PR TITLE
Render constants as 'const' rather than 'static' values

### DIFF
--- a/src/Generation/Generator/Renderer/Public/Constants/Constants.cs
+++ b/src/Generation/Generator/Renderer/Public/Constants/Constants.cs
@@ -34,6 +34,6 @@ public partial class Constants
 
         return @$"
 {PlatformSupportAttribute.Render(constant as GirModel.PlatformDependent)}
-public static {renderableConstant.Type} {renderableConstant.Name} = {renderableConstant.Value};";
+public const {renderableConstant.Type} {renderableConstant.Name} = {renderableConstant.Value};";
     }
 }

--- a/src/Native/GirTestLib/girtest-constant-tester.h
+++ b/src/Native/GirTestLib/girtest-constant-tester.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Constant values in the GirTest namespace.
+
+#define GIRTEST_INTVAL 42
+
+#define GIRTEST_STRVAL "string value"

--- a/src/Native/GirTestLib/girtest.h
+++ b/src/Native/GirTestLib/girtest.h
@@ -2,6 +2,7 @@
 
 // Simple C library to test the generated bindings.
 #include "girtest-class-tester.h"
+#include "girtest-constant-tester.h"
 #include "girtest-error-tester.h"
 #include "girtest-primitive-value-type-tester.h"
 #include "girtest-property-tester.h"

--- a/src/Native/GirTestLib/meson.build
+++ b/src/Native/GirTestLib/meson.build
@@ -5,6 +5,7 @@ gobject_dep = dependency('gobject-2.0', version: '>= 2.66.0')
 header_files = [
   'girtest.h',
   'girtest-class-tester.h',
+  'girtest-constant-tester.h',
   'girtest-error-tester.h',
   'girtest-primitive-value-type-tester.h',
   'girtest-property-tester.h',

--- a/src/Tests/Libs/GirTest-0.1.Tests/ConstantTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/ConstantTest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GirTest.Tests;
+
+[TestClass, TestCategory("BindingTest")]
+public class ConstantTest : Test
+{
+    [TestMethod]
+    public void ConstantValuesShouldBeConst()
+    {
+        // Verify that the constants are 'const' values, not just 'static'.
+        const int int_val = GirTest.Constants.INTVAL;
+        int_val.Should().Be(42);
+
+        const string str_val = GirTest.Constants.STRVAL;
+        str_val.Should().Be("string value");
+    }
+}


### PR DESCRIPTION
Also added some test coverage to GirTest for generating constants

Fixes: #820

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
