### PR TITLE
Fix string double free bug in case of full ownership transfer

### DIFF
--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/PlatformString.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/PlatformString.cs
@@ -40,9 +40,14 @@ internal class PlatformString : ToNativeParameterConverter
         }
         else
         {
-            string ownedHandleTypeName = parameter.Parameter.Nullable
-                ? Model.PlatformString.GetInternalNullableOwnedHandleName()
-                : Model.PlatformString.GetInternalNonNullableOwnedHandleName();
+            var ownedHandleTypeName = parameter.Parameter switch
+            {
+                { Nullable: true, Transfer: GirModel.Transfer.Full } => Model.PlatformString.GetInternalNullableUnownedHandleName(),
+                { Nullable: true, Transfer: GirModel.Transfer.None } => Model.PlatformString.GetInternalNullableOwnedHandleName(),
+                { Nullable: false, Transfer: GirModel.Transfer.Full } => Model.PlatformString.GetInternalNonNullableUnownedHandleName(),
+                { Nullable: false, Transfer: GirModel.Transfer.None } => Model.PlatformString.GetInternalNonNullableOwnedHandleName(),
+                _ => throw new Exception($"Parameter {parameter.Parameter.Name} of type {parameter.Parameter.AnyTypeOrVarArgs} not supported")
+            };
 
             parameter.SetExpression($"using var {nativeVariableName} = {ownedHandleTypeName}.Create({parameterName});");
             parameter.SetCallName(nativeVariableName);

--- a/src/Libs/GLib-2.0/Internal/StringHelper.cs
+++ b/src/Libs/GLib-2.0/Internal/StringHelper.cs
@@ -66,7 +66,7 @@ public static class StringHelper
             return IntPtr.Zero;
 
         var bytes = Encoding.UTF8.GetBytes(str);
-        IntPtr alloc = GLib.Internal.Functions.Malloc((uint) (bytes.Length + 1));
+        IntPtr alloc = Functions.Malloc((uint) (bytes.Length + 1));
         Marshal.Copy(bytes, 0, alloc, bytes.Length);
         Marshal.WriteByte(alloc, bytes.Length, 0);
 

--- a/src/Libs/GLib-2.0/Internal/Utf8StringHandle.cs
+++ b/src/Libs/GLib-2.0/Internal/Utf8StringHandle.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace GLib.Internal;
 
@@ -27,6 +26,18 @@ public class NullableUtf8StringUnownedHandle : NullableUtf8StringHandle
 {
     private NullableUtf8StringUnownedHandle() : base(false)
     {
+    }
+
+    /// <summary>
+    /// Creates a nullable utf8 string handle for the given string.
+    /// </summary>
+    /// <param name="s">The string which should be used to create the handle.</param>
+    /// <returns>A nullable utf8 string handle</returns>
+    public static NullableUtf8StringUnownedHandle Create(string? s)
+    {
+        var alloc = new NullableUtf8StringUnownedHandle();
+        alloc.SetHandle(StringHelper.StringToPtrUtf8(s));
+        return alloc;
     }
 
     protected override bool ReleaseHandle()
@@ -91,6 +102,18 @@ public class NonNullableUtf8StringUnownedHandle : NonNullableUtf8StringHandle
 {
     private NonNullableUtf8StringUnownedHandle() : base(false)
     {
+    }
+
+    /// <summary>
+    /// Creates a non nullable utf8 string handle for the given string.
+    /// </summary>
+    /// <param name="s">The string which should be used to create the handle.</param>
+    /// <returns>A non nullable utf8 string handle</returns>
+    public static NonNullableUtf8StringUnownedHandle Create(string s)
+    {
+        var alloc = new NonNullableUtf8StringUnownedHandle();
+        alloc.SetHandle(StringHelper.StringToPtrUtf8(s));
+        return alloc;
     }
 
     protected override bool ReleaseHandle()

--- a/src/Native/GirTestLib/girtest-string-tester.c
+++ b/src/Native/GirTestLib/girtest-string-tester.c
@@ -38,6 +38,18 @@ girtest_string_tester_utf8_in(const gchar *s)
 }
 
 /**
+ * girtest_string_tester_utf8_in_transfer_full:
+ * @s: (in) (transfer full): Pointer to the start of a UTF-8 encoded string
+ *
+ * Test for a nullable UTF-8 string parameter which is freed immediately.
+ */
+void
+girtest_string_tester_utf8_in_transfer_full(gchar *s)
+{
+    g_free(s);
+}
+
+/**
  * girtest_string_tester_utf8_in_nullable:
  * @s: (in) (nullable): Pointer to the start of a UTF-8 encoded string, or NULL.
  *
@@ -49,6 +61,19 @@ int
 girtest_string_tester_utf8_in_nullable(const gchar *s)
 {
     return s ? girtest_string_tester_utf8_in(s) : -1;
+}
+
+/**
+ * girtest_string_tester_utf8_in_nullable_transfer_full:
+ * @s: (in) (nullable) (transfer full): Pointer to the start of a UTF-8 encoded string, or NULL.
+ *
+ * Test for a nullable UTF-8 string parameter which is freed immediately if not NULL.
+ */
+void
+girtest_string_tester_utf8_in_nullable_transfer_full(gchar *s)
+{
+    if(s)
+        g_free(s);
 }
 
 /**
@@ -73,6 +98,22 @@ girtest_string_tester_filename_in(const gchar *s)
 }
 
 /**
+ * girtest_string_tester_filename_in_transfer_full:
+ * @s: (in) (type filename) (transfer full): A string in the filename encoding.
+ *
+ * Test for a filename string parameter which is freed immediately.
+ */
+void
+girtest_string_tester_filename_in_transfer_full(gchar *s)
+{
+    GError *error = NULL;
+    gchar *utf8 = g_filename_to_utf8(s, -1, NULL, NULL, &error);
+    g_assert_no_error(error);
+    g_free(utf8);
+    g_free(s);
+}
+
+/**
  * girtest_string_tester_filename_in_nullable:
  * @s: (in) (type filename) (nullable): A string in the filename encoding, or NULL.
  *
@@ -84,6 +125,25 @@ int
 girtest_string_tester_filename_in_nullable(const gchar *s)
 {
     return s ? girtest_string_tester_filename_in(s) : -1;
+}
+
+/**
+ * girtest_string_tester_filename_in_nullable_transfer_full:
+ * @s: (in) (nullable) (type filename) (transfer full): A string in the filename encoding, or NULL.
+ *
+ * Test for a filename string parameter which is freed immediately if not NULL
+ */
+void
+girtest_string_tester_filename_in_nullable_transfer_full(gchar *s)
+{    
+    if(s)
+    {
+        GError *error = NULL;
+        gchar *utf8 = g_filename_to_utf8(s, -1, NULL, NULL, &error);
+        g_assert_no_error(error);
+        g_free(utf8);
+        g_free(s);
+    }
 }
 
 /**

--- a/src/Native/GirTestLib/girtest-string-tester.h
+++ b/src/Native/GirTestLib/girtest-string-tester.h
@@ -14,14 +14,26 @@ G_DECLARE_FINAL_TYPE(GirTestStringTester, girtest_string_tester,
 int
 girtest_string_tester_utf8_in(const gchar *s);
 
+void
+girtest_string_tester_utf8_in_transfer_full(gchar *s);
+
 int
 girtest_string_tester_utf8_in_nullable(const gchar *s);
+
+void
+girtest_string_tester_utf8_in_nullable_transfer_full(gchar *s);
 
 int
 girtest_string_tester_filename_in(const gchar *s);
 
+void
+girtest_string_tester_filename_in_transfer_full(gchar *s);
+
 int
 girtest_string_tester_filename_in_nullable(const gchar *s);
+
+void
+girtest_string_tester_filename_in_nullable_transfer_full(gchar *s);
 
 gchar *
 girtest_string_tester_utf8_return_transfer_full(const gchar *s);

--- a/src/Tests/Libs/GirTest-0.1.Tests/StringTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/StringTest.cs
@@ -12,10 +12,29 @@ public class StringTest : Test
     private const string TestString = "a\u00f6bc";
 
     [TestMethod]
+    public void InUtf8ParameterWithFullTransferDoNotDoubleFree()
+    {
+        //In case a double free bug occurs the runtime crashes and the "dotnet test" command returns an error
+
+        StringTester.Utf8InTransferFull(TestString);
+        StringTester.Utf8InNullableTransferFull(TestString);
+        StringTester.Utf8InNullableTransferFull(null);
+    }
+
+    [TestMethod]
+    public void InFilenameParameterWithFullTransferDoNotDoubleFree()
+    {
+        //In case a double free bug occurs the runtime crashes and the "dotnet test" command returns an error
+
+        StringTester.FilenameInTransferFull(TestString);
+        StringTester.FilenameInNullableTransferFull(TestString);
+        StringTester.FilenameInNullableTransferFull(null);
+    }
+
+    [TestMethod]
     public void InUtf8ParameterShouldSucceed()
     {
         StringTester.Utf8In(TestString).Should().Be(TestString.Length);
-
         StringTester.Utf8InNullable(TestString).Should().Be(TestString.Length);
         StringTester.Utf8InNullable(null).Should().Be(-1);
     }


### PR DESCRIPTION
- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL 

If a method takes in a string and ownership is transferred to the method an unowned string is generated as this string is not freed by dotnet and can then be freed by C.

Fixes: #847