### PR TITLE
Render properties which are named like it's containing class

### DIFF
--- a/src/Generation/Generator/Fixer/Class/PropertyNamedLikeClassFixer.cs
+++ b/src/Generation/Generator/Fixer/Class/PropertyNamedLikeClassFixer.cs
@@ -8,10 +8,11 @@ internal class PropertyNamedLikeClassFixer : Fixer<GirModel.Class>
     {
         foreach (var property in @class.Properties)
         {
-            if (Property.GetName(property) == @class.Name)
+            var name = Property.GetName(property);
+            if (name == @class.Name)
             {
-                Property.Disable(property);
-                Log.Warning($"Property {property.Name} is named like its containing class {@class.Namespace.Name}.{@class.Name}. This is not allowed. The property should be created with a suffix and be rewritten to it's original name");
+                Property.SetName(property, $"{name}_");
+                Log.Information($"Property {property.Name} is named like its containing class {@class.Namespace.Name}.{@class.Name}. This is not allowed. The property should be created with a suffix and be rewritten to it's original name");
             }
         }
 
@@ -19,10 +20,11 @@ internal class PropertyNamedLikeClassFixer : Fixer<GirModel.Class>
         {
             foreach (var interfaceProperty in @interface.Properties)
             {
-                if (Property.GetName(interfaceProperty) == @class.Name)
+                var name = Property.GetName(interfaceProperty);
+                if (name == @class.Name)
                 {
-                    Property.Disable(interfaceProperty);
-                    Log.Warning($"Property {interfaceProperty.Name} of interface {@interface.Namespace.Name}.{@interface.Name} is named like its containing class {@class.Namespace.Name}.{@class.Name}. This is not allowed. The property should be created with a suffix and be rewritten to it's original name");
+                    Property.SetName(interfaceProperty, $"{name}_");
+                    Log.Information($"Property {interfaceProperty.Name} of interface {@interface.Namespace.Name}.{@interface.Name} is named like its containing class {@class.Namespace.Name}.{@class.Name}. This is not allowed. The property should be created with a suffix and be rewritten to it's original name");
                 }
             }
         }

--- a/src/Generation/Generator/Model/Property.cs
+++ b/src/Generation/Generator/Model/Property.cs
@@ -8,10 +8,23 @@ namespace Generator.Model;
 internal static partial class Property
 {
     private static readonly HashSet<GirModel.Property> ImplementExplicitly = new();
+    private static readonly Dictionary<GirModel.Property, string> FixedNames = new();
 
     public static string GetName(GirModel.Property property)
     {
+        //Does not need a lock as it is called only after all insertions are done.
+        if (FixedNames.TryGetValue(property, out var value))
+            return value;
+
         return property.Name.ToPascalCase();
+    }
+
+    internal static void SetName(GirModel.Property property, string name)
+    {
+        lock (FixedNames)
+        {
+            FixedNames[property] = name;
+        }
     }
 
     public static string GetDescriptorName(GirModel.Property property)

--- a/src/Native/GirTestLib/girtest-property-tester.c
+++ b/src/Native/GirTestLib/girtest-property-tester.c
@@ -9,6 +9,7 @@
 typedef enum
 {
     PROP_STRING_VALUE = 1,
+    PROP_PROPERTY_TESTER = 2,
     N_PROPERTIES
 } PropertyTesterProperty;
 
@@ -17,6 +18,7 @@ struct _GirTestPropertyTester
     GObject parent_instance;
 
     gchar *string_value;
+    gchar *property_tester;
 };
 
 G_DEFINE_TYPE(GirTestPropertyTester, girtest_property_tester, G_TYPE_OBJECT)
@@ -37,6 +39,9 @@ girtest_property_tester_get_property (GObject    *object,
     case PROP_STRING_VALUE:
         g_value_set_string (value, self->string_value);
         break;
+    case PROP_PROPERTY_TESTER:
+        g_value_set_string (value, self->property_tester);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -54,6 +59,9 @@ girtest_property_tester_set_property (GObject      *object,
     {
     case PROP_STRING_VALUE:
         self->string_value = g_value_dup_string (value);
+        break;
+    case PROP_PROPERTY_TESTER:
+        self->property_tester = g_value_dup_string (value);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -77,6 +85,13 @@ girtest_property_tester_class_init(GirTestPropertyTesterClass *class)
       g_param_spec_string ("string-value",
                            "String Value",
                            "A string value",
+                           NULL  /* default value */,
+                           G_PARAM_READWRITE);
+
+    properties[PROP_PROPERTY_TESTER] =
+      g_param_spec_string ("property-tester",
+                           "Property Tester",
+                           "A string value named like it's class",
                            NULL  /* default value */,
                            G_PARAM_READWRITE);
 

--- a/src/Tests/Libs/GirTest-0.1.Tests/PropertyTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/PropertyTest.cs
@@ -27,4 +27,12 @@ public class PropertyTest : Test
         obj.StringValue = null;
         obj.StringValue.Should().BeNull();
     }
+
+    [TestMethod]
+    public void PropertyNamedLikeClass()
+    {
+        //Properties named like a class are suffixed with an underscore.
+        var obj = PropertyTester.New();
+        obj.PropertyTester_ = "test";
+    }
 }


### PR DESCRIPTION
Render properties named like it's containing class instead of disabling them. This adds a suffix to the property name to avoid a conflict with the class name.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

Part of #792 