### PR TITLE
Disable method if annotations are wrong

### DIFF
--- a/src/Generation/Generator/Fixer/Class/PublicMethodsWithInvalidOutParameterFixer.cs
+++ b/src/Generation/Generator/Fixer/Class/PublicMethodsWithInvalidOutParameterFixer.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using GirModel;
+
+namespace Generator.Fixer.Class;
+
+internal class PublicMethodsWithInvalidOutParameterFixer : Fixer<GirModel.Class>
+{
+    public void Fixup(GirModel.Class @class)
+    {
+        foreach (var method in @class.Methods)
+        {
+            var parameter = method.Parameters.FirstOrDefault(x => x is { CallerAllocates: true, Direction: Direction.Out }
+                                                                  && x.AnyTypeOrVarArgs.TryPickT0(out var anyType, out _)
+                                                                  && anyType.TryPickT1(out var arrayType, out _)
+                                                                  && arrayType.Length is not null);
+
+            if (parameter is null)
+                continue;
+
+            var lengthParameter = method.Parameters.ElementAt(parameter.AnyTypeOrVarArgs.AsT0.AsT1.Length!.Value);
+            if (lengthParameter.Direction == Direction.Out)
+            {
+                Log.Warning($"Disabling method {method.CIdentifier} as it has a size parameter which is defined as out parameter which is wrong. Consider marking the parameter explicitly as (in) in the doc comments.");
+                Model.Method.Disable(method);
+            }
+        }
+    }
+}

--- a/src/Generation/Generator/Fixer/Classes.cs
+++ b/src/Generation/Generator/Fixer/Classes.cs
@@ -12,7 +12,8 @@ public static class Classes
         new PropertyNamedLikeClassFixer(),
         new PropertyLikeInterfacePropertyFixer(),
         new InterfaceMethodsCollidingWithClassMethodsFixer(),
-        new InterfaceMethodsCollidingWithClassConstructorsFixer()
+        new InterfaceMethodsCollidingWithClassConstructorsFixer(),
+        new PublicMethodsWithInvalidOutParameterFixer()
     };
 
     public static void Fixup(IEnumerable<GirModel.Class> classes)


### PR DESCRIPTION
Disable methods if they have a caller allocated out parameter with a size parameter with the direction out. The out size parameter does not make sense if the first parameter is caller allocated. In this case the size parameter must be caller allocated, too.

As this can't be fixed during render time the method is disabled completely. To fix this the gir file must be fixed upstream.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
