### PR TITLE
Avoid printing to the console when registering a GType.

### DIFF
--- a/src/Libs/GObject-2.0/Internal/TypeRegistrar.cs
+++ b/src/Libs/GObject-2.0/Internal/TypeRegistrar.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace GObject.Internal;
@@ -56,7 +57,7 @@ public static class TypeRegistrar
         };
 
         // Perform Registration
-        Console.WriteLine($"Registering new type {qualifiedName} with parent {parentType.ToString()}");
+        Debug.WriteLine($"Registering new type {qualifiedName} with parent {parentType.ToString()}");
 
         TypeInfoHandle handle = TypeInfoManagedHandle.Create(typeInfo);
         var typeid = Functions.TypeRegisterStatic(parentType.Value, GLib.Internal.NonNullableUtf8StringOwnedHandle.Create(qualifiedName), handle, 0);


### PR DESCRIPTION
This just switches to `Debug.WriteLine`, similar to other classes like `ObjectMapper`.
I also searched for other print statements and this seems to be the only one printing to the console, outside of the samples.

Fixes: #844

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
