### PR TITLE
Fix nullable warnings for interface parameters.

### DIFF
--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/Interface.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/Interface.cs
@@ -15,10 +15,11 @@ internal class Interface : ToNativeParameterConverter
             throw new NotImplementedException($"{parameter.Parameter.AnyTypeOrVarArgs}: Interface parameter with direction != in not yet supported");
 
         var parameterName = Model.Parameter.GetName(parameter.Parameter);
-        var nativeVariableName = parameterName + "Native";
+        var callParameter = parameter.Parameter.Nullable
+            ? parameterName + "?.Handle ?? IntPtr.Zero"
+            : parameterName + ".Handle";
 
         parameter.SetSignatureName(parameterName);
-        parameter.SetCallName(nativeVariableName);
-        parameter.SetExpression($"var {nativeVariableName} = ({parameterName} as GObject.Object).Handle;");
+        parameter.SetCallName(callParameter);
     }
 }


### PR DESCRIPTION
This could generate nullable warnings from the `as` expression producing null, or from the parameter being nullable. Since interfaces inherit from the `GLib.IHandle` interface, this cast can be avoided by just using its `Handle` property. This is done inline, similar to how class parameters are converted to native parameters.

This reduces the number of warnings in the build from 6552 to 5792

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
