### PR TITLE
Add an event for unhandled exceptions from delegates invoked by native code

### DIFF
--- a/src/Libs/GLib-2.0/Public/UnhandledException.cs
+++ b/src/Libs/GLib-2.0/Public/UnhandledException.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace GLib;
+
+/// <summary>
+/// Allows handlings exceptions which can't cross the native code boundary and
+/// would terminate the application.
+/// </summary>
+public static class UnhandledException
+{
+    /// <summary>
+    /// Invoked if an exception is raised which reaches the native code boundary.
+    /// This can be used by applications to handle these exceptions gracefully
+    /// without terminating the application.
+    /// </summary>
+    public static event EventHandler<UnhandledExceptionEventArgs>? Raised;
+
+    /// <summary>
+    /// Call this method to invoke the "Raised" event. If the event has no subscribers,
+    /// the application is terminated.
+    /// </summary>
+    /// <remarks>
+    /// This method is not intended to be called by application code, and should only
+    /// be called by code which catches an exception that would otherwise terminate
+    /// the application by unwinding to the native code boundary.
+    /// </remarks>
+    public static void Raise(Exception e)
+    {
+        if (Raised is null)
+        {
+            Console.Error.WriteLine($"{nameof(GLib.UnhandledException)} - unhandled exception: {e}");
+            Environment.Exit(1);
+        }
+        else
+        {
+            Raised.Invoke(null, new UnhandledExceptionEventArgs(e, false));
+        }
+    }
+}

--- a/src/Libs/GObject-2.0/Public/Closure.cs
+++ b/src/Libs/GObject-2.0/Public/Closure.cs
@@ -42,7 +42,14 @@ public partial class Closure : IDisposable
             .Select(valueHandle => new Value(valueHandle))
             .ToArray();
 
-        _callback(returnValue, paramValues);
+        try
+        {
+            _callback(returnValue, paramValues);
+        }
+        catch (Exception e)
+        {
+            GLib.UnhandledException.Raise(e);
+        }
     }
 
     public void Dispose()

--- a/src/Tests/Libs/GirTest-0.1.Tests/UnhandledExceptionTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/UnhandledExceptionTest.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GirTest.Tests;
+
+[TestClass, TestCategory("BindingTest")]
+public class UnhandledExceptionTest : Test
+{
+    [TestMethod]
+    public void SupportsSignalHandlers()
+    {
+        var tester = ReturningSignalTester.New();
+        tester.OnReturnBool += (_, _) =>
+        {
+            throw new NotImplementedException();
+        };
+
+        bool exceptionCaught = false;
+        GLib.UnhandledException.Raised += (_, args) =>
+        {
+            exceptionCaught = args.ExceptionObject is NotImplementedException;
+        };
+
+        tester.EmitReturnBool().Should().Be(false);
+        exceptionCaught.Should().Be(true);
+    }
+}


### PR DESCRIPTION
These unhandled exceptions would otherwise immediately terminate the program once they reach the native code boundary. This event lets applications do any logging / message dialogs etc and decide whether they want to terminate the program or attempt to continue.

Currently this only supports signal handlers for testing purposes, but would need to be extended to the other callback types.

Bug: #845

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
