### PR TITLE
Allows to add an exception handler for unhandled exceptions

### DIFF
--- a/src/Libs/GLib-2.0/Public/UnhandledException.cs
+++ b/src/Libs/GLib-2.0/Public/UnhandledException.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace GLib;
+
+/// <summary>
+/// Allows handling exceptions which can't cross the native code boundary and
+/// would terminate the application.
+/// </summary>
+public static class UnhandledException
+{
+    private static Action<Exception>? ExceptionHandler;
+
+    /// <summary>
+    /// Sets an action which is invoked if an exception is raised which reaches the native code boundary.
+    /// This can be used by applications to handle these exceptions gracefully
+    /// without terminating the application.
+    /// </summary>
+    /// <param name="handler">Invoked if an unhandled exception occurs</param>
+    public static void SetHandler(Action<Exception>? handler)
+    {
+        ExceptionHandler = handler;
+    }
+
+    /// <summary>
+    /// Call this method to invoke the exception handler. If there is no exception
+    /// handler registered the application is terminated.
+    /// </summary>
+    /// <remarks>
+    /// This method is not intended to be called by application code, and should only
+    /// be called by code which catches an exception that would otherwise terminate
+    /// the application by unwinding to the native code boundary.
+    /// </remarks>
+    public static void Raise(Exception e)
+    {
+        if (ExceptionHandler is null)
+        {
+            Console.Error.WriteLine($"{nameof(GLib.UnhandledException)} - unhandled exception: {e}");
+            Environment.Exit(1);
+        }
+        else
+        {
+            ExceptionHandler(e);
+        }
+    }
+}

--- a/src/Libs/GObject-2.0/Public/Closure.cs
+++ b/src/Libs/GObject-2.0/Public/Closure.cs
@@ -42,7 +42,14 @@ public partial class Closure : IDisposable
             .Select(valueHandle => new Value(valueHandle))
             .ToArray();
 
-        _callback(returnValue, paramValues);
+        try
+        {
+            _callback(returnValue, paramValues);
+        }
+        catch (Exception e)
+        {
+            GLib.UnhandledException.Raise(e);
+        }
     }
 
     public void Dispose()

--- a/src/Tests/Libs/GirTest-0.1.Tests/UnhandledExceptionTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/UnhandledExceptionTest.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GirTest.Tests;
+
+[TestClass, TestCategory("BindingTest")]
+public class UnhandledExceptionTest : Test
+{
+
+    //Important: Be aware that an unhandled exception handler is
+    //set globally. In case of unit tests being executed in
+    //parallel this could lead to unintended side effects.
+
+    [TestMethod]
+    public void SupportsSignalHandlers()
+    {
+        var tester = ReturningSignalTester.New();
+        tester.OnReturnBool += (_, _) =>
+        {
+            throw new NotImplementedException();
+        };
+
+        bool exceptionCaught = false;
+        GLib.UnhandledException.SetHandler(e =>
+        {
+            exceptionCaught = e is NotImplementedException;
+        });
+
+        tester.EmitReturnBool().Should().Be(false);
+        exceptionCaught.Should().Be(true);
+    }
+}


### PR DESCRIPTION
These unhandled exceptions would otherwise immediately terminate the program once they reach the native code boundary. An exception handler lets applications do any logging / message dialogs etc and decide whether they want to terminate the program or attempt to continue.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

@cameronwhite I took your initial code and updated it to not use an event. I think this is a simpler approach for now.