### PR TITLE
Add tests for callbacks.

### DIFF
--- a/src/Native/GirTestLib/girtest-callback-tester.c
+++ b/src/Native/GirTestLib/girtest-callback-tester.c
@@ -1,0 +1,95 @@
+#include "girtest-callback-tester.h"
+
+/**
+ * GirTestCallbackTester:
+ *
+ * Contains functions for testing bindings with callbacks.
+ */
+
+struct _GirTestCallbackTester
+{
+    GObject parent_instance;
+
+    GirTestIntCallback notified_callback;
+    gpointer notified_data;
+    GDestroyNotify notified_destroy;
+};
+
+G_DEFINE_TYPE(GirTestCallbackTester, girtest_callback_tester, G_TYPE_OBJECT)
+
+static void
+girtest_callback_tester_init(GirTestCallbackTester *tester)
+{
+    tester->notified_callback = NULL;
+    tester->notified_data = NULL;
+    tester->notified_destroy = NULL;
+}
+
+static void
+girtest_callback_tester_class_init(GirTestCallbackTesterClass *class)
+{
+}
+
+/**
+ * girtest_callback_tester_new:
+ *
+ * Creates a new `GirTestCallbackTester`.
+ *
+ * Returns: The newly created `GirTestCallbackTester`.
+ */
+GirTestCallbackTester*
+girtest_callback_tester_new (void)
+{
+    return g_object_new (GIRTEST_TYPE_CALLBACK_TESTER, NULL);
+}
+
+/**
+ * girtest_callback_tester_set_notified_callback:
+ * @callback: (scope notified): a function to set as the notified callback.
+ * @data: data to pass to @notify.
+ * @notify: (nullable): function to call when the callback is removed, or %NULL.
+ *
+ * Assigns a callback with 'notified' scope, which can later be called with
+ * girtest_callback_tester_run_notified_callback().
+ */
+void
+girtest_callback_tester_set_notified_callback(GirTestCallbackTester *tester,
+                                              GirTestIntCallback callback,
+                                              gpointer data,
+                                              GDestroyNotify notify)
+{
+    tester->notified_callback = callback;
+    tester->notified_data = data;
+    tester->notified_destroy = notify;
+}
+
+/**
+ * girtest_callback_tester_run_notified_callback:
+ * @value: value to pass to the callback.
+ * @done: If true, runs the GDestroyNotify callback.
+ *
+ * Runs the notified callback with the provided value, or returns -1 if the
+ * callback was not set or has been destroyed.
+ */
+int
+girtest_callback_tester_run_notified_callback(GirTestCallbackTester *tester,
+                                              int value,
+                                              gboolean done)
+{
+    if (!tester->notified_callback)
+        return -1;
+
+    int result = tester->notified_callback(value);
+
+    if (done)
+    {
+        if (tester->notified_destroy)
+            tester->notified_destroy(tester->notified_data);
+
+        tester->notified_callback = NULL;
+        tester->notified_data = NULL;
+        tester->notified_destroy = NULL;
+    }
+
+    return result;
+}

--- a/src/Native/GirTestLib/girtest-callback-tester.h
+++ b/src/Native/GirTestLib/girtest-callback-tester.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define GIRTEST_TYPE_CALLBACK_TESTER girtest_callback_tester_get_type()
+
+G_DECLARE_FINAL_TYPE(GirTestCallbackTester, girtest_callback_tester,
+                     GIRTEST, CALLBACK_TESTER, GObject)
+
+typedef int (*GirTestIntCallback)  (int val);
+
+GirTestCallbackTester*
+girtest_callback_tester_new (void);
+
+void
+girtest_callback_tester_set_notified_callback(GirTestCallbackTester *tester,
+                                              GirTestIntCallback callback,
+                                              gpointer data,
+                                              GDestroyNotify notify);
+
+int
+girtest_callback_tester_run_notified_callback(GirTestCallbackTester *tester,
+                                              int value,
+                                              gboolean done);
+
+G_END_DECLS
+

--- a/src/Native/GirTestLib/girtest.h
+++ b/src/Native/GirTestLib/girtest.h
@@ -2,6 +2,7 @@
 
 // Simple C library to test the generated bindings.
 #include "girtest-alias-tester.h"
+#include "girtest-callback-tester.h"
 #include "girtest-class-tester.h"
 #include "girtest-constant-tester.h"
 #include "girtest-error-tester.h"

--- a/src/Native/GirTestLib/meson.build
+++ b/src/Native/GirTestLib/meson.build
@@ -5,6 +5,7 @@ gobject_dep = dependency('gobject-2.0', version: '>= 2.66.0')
 header_files = [
   'girtest.h',
   'girtest-alias-tester.h',
+  'girtest-callback-tester.h',
   'girtest-class-tester.h',
   'girtest-constant-tester.h',
   'girtest-error-tester.h',
@@ -17,6 +18,7 @@ header_files = [
 
 source_files = [
   'girtest-alias-tester.c',
+  'girtest-callback-tester.c',
   'girtest-class-tester.c',
   'girtest-error-tester.c',
   'girtest-primitive-value-type-tester.c',

--- a/src/Tests/Libs/GirTest-0.1.Tests/CallbackTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/CallbackTest.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GirTest.Tests;
+
+[TestClass, TestCategory("BindingTest")]
+public class CallbackTest : Test
+{
+    [TestMethod]
+    public void SupportsNotifiedCallbacks()
+    {
+        var tester = CallbackTester.New();
+
+        tester.SetNotifiedCallback((val) => 2 * val);
+
+        tester.RunNotifiedCallback(2, done: false).Should().Be(4);
+        tester.RunNotifiedCallback(3, done: false).Should().Be(6);
+        tester.RunNotifiedCallback(4, done: true).Should().Be(8);
+        tester.RunNotifiedCallback(5, done: false).Should().Be(-1);
+    }
+}


### PR DESCRIPTION
This is good to have in general, but is also needed for #845 where we want to test exception handling for callbacks

Callbacks with `notified` scope are the only type that currently has full support for generating public bindings (see https://github.com/gircore/gir.core/blob/5e2b002aadc40dbf4eadfb86fdfcce03a0f8ef2e/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/Callback.cs#L27)

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
