### PR TITLE
Set the main thread's apartment state when initializing GDK

### DIFF
--- a/src/Libs/Gdk-4.0/Public/Module.cs
+++ b/src/Libs/Gdk-4.0/Public/Module.cs
@@ -1,4 +1,7 @@
-﻿namespace Gdk;
+﻿using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Gdk;
 
 public class Module
 {
@@ -13,6 +16,15 @@ public class Module
 
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();
+
+        // On Windows, GDK requires the main thread's apartment state to be STA.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // In order to successfully switch from MTA to STA, it is necessary
+            // to first set it to Unknown.
+            Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
+            Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
+        }
 
         IsInitialized = true;
     }


### PR DESCRIPTION
This seems to be the logical place to do it since the startup error comes from GDK, and this also ensures it's done automatically without any extra steps to document for users.

This is wrapped in a check for whether we're running on Windows, to avoid warnings from the `SupportedOSPlatform` attribute on `SetApartmentState()`

I've tested on Windows with `Samples/Gtk-4.0/Window` and verified that this works

Fixes: #864

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
