### PR TITLE
Sync'ed dependencies in csproj/gir/Module.cs

### DIFF
--- a/src/Libs/Adw-1/Adw-1.csproj
+++ b/src/Libs/Adw-1/Adw-1.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\Gtk-4.0\Gtk-4.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.Adw-1</PackageId>
     <RootNamespace>Adw</RootNamespace>
     <Description>C# bindings for libadwaita.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Gio-2.0\Gio-2.0.csproj" />
+    <ProjectReference Include="..\Gtk-4.0\Gtk-4.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/Adw-1/Public/Module.cs
+++ b/src/Libs/Adw-1/Public/Module.cs
@@ -9,6 +9,7 @@ public class Module
         if (IsInitialized)
             return;
 
+        Gio.Module.Initialize();
         Gtk.Module.Initialize();
 
         Internal.ImportResolver.RegisterAsDllImportResolver();

--- a/src/Libs/GObject-2.0/GObject-2.0.csproj
+++ b/src/Libs/GObject-2.0/GObject-2.0.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>GObject-2.0.Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GLib-2.0\GLib-2.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.GObject-2.0</PackageId>
     <RootNamespace>GObject</RootNamespace>
     <Description>C# bindings for GObject.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GLib-2.0\GLib-2.0.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>GObject-2.0.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/Libs/Gdk-4.0/Gdk-4.0.csproj
+++ b/src/Libs/Gdk-4.0/Gdk-4.0.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\cairo-1.0\cairo-1.0.csproj" />
-    <ProjectReference Include="..\GdkPixbuf-2.0\GdkPixbuf-2.0.csproj" />
-    <ProjectReference Include="..\Gio-2.0\Gio-2.0.csproj" />
-    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
-    <ProjectReference Include="..\Pango-1.0\Pango-1.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.Gdk-4.0</PackageId>
     <RootNamespace>Gdk</RootNamespace>
     <Description>C# bindings for Gdk.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\cairo-1.0\cairo-1.0.csproj" />
+    <ProjectReference Include="..\GdkPixbuf-2.0\GdkPixbuf-2.0.csproj" />
+    <ProjectReference Include="..\Gio-2.0\Gio-2.0.csproj" />
+    <ProjectReference Include="..\Pango-1.0\Pango-1.0.csproj" />
+    <ProjectReference Include="..\PangoCairo-1.0\PangoCairo-1.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/Gdk-4.0/Public/Module.cs
+++ b/src/Libs/Gdk-4.0/Public/Module.cs
@@ -12,7 +12,11 @@ public class Module
         if (IsInitialized)
             return;
 
-        GObject.Module.Initialize();
+        Cairo.Module.Initialize();
+        GdkPixbuf.Module.Initialize();
+        Gio.Module.Initialize();
+        Pango.Module.Initialize();
+        PangoCairo.Module.Initialize();
 
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();

--- a/src/Libs/GdkPixbuf-2.0/GdkPixbuf-2.0.csproj
+++ b/src/Libs/GdkPixbuf-2.0/GdkPixbuf-2.0.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\Gio-2.0\Gio-2.0.csproj" />
-    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.GdkPixbuf-2.0</PackageId>
     <RootNamespace>GdkPixbuf</RootNamespace>
     <Description>C# bindings for GdkPixbuf.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Gio-2.0\Gio-2.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/GdkPixbuf-2.0/Public/Module.cs
+++ b/src/Libs/GdkPixbuf-2.0/Public/Module.cs
@@ -9,7 +9,7 @@ public class Module
         if (IsInitialized)
             return;
 
-        GObject.Module.Initialize();
+        Gio.Module.Initialize();
 
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();

--- a/src/Libs/Gio-2.0/Gio-2.0.csproj
+++ b/src/Libs/Gio-2.0/Gio-2.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <PackageId>GirCore.Gio-2.0</PackageId>
     <RootNamespace>Gio</RootNamespace>

--- a/src/Libs/Graphene-1.0/Graphene-1.0.csproj
+++ b/src/Libs/Graphene-1.0/Graphene-1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <PackageId>GirCore.Graphene-1.0</PackageId>
     <RootNamespace>Graphene</RootNamespace>

--- a/src/Libs/Gsk-4.0/Gsk-4.0.csproj
+++ b/src/Libs/Gsk-4.0/Gsk-4.0.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\Gdk-4.0\Gdk-4.0.csproj" />
-    <ProjectReference Include="..\Graphene-1.0\Graphene-1.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.Gsk-4.0</PackageId>
     <RootNamespace>Gdk</RootNamespace>
     <Description>C# bindings for Gsk.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Gdk-4.0\Gdk-4.0.csproj" />
+    <ProjectReference Include="..\Graphene-1.0\Graphene-1.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/Gsk-4.0/Public/Module.cs
+++ b/src/Libs/Gsk-4.0/Public/Module.cs
@@ -9,6 +9,9 @@ public class Module
         if (IsInitialized)
             return;
 
+        Gdk.Module.Initialize();
+        Graphene.Module.Initialize();
+
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();
 

--- a/src/Libs/Gst-1.0/Gst-1.0.csproj
+++ b/src/Libs/Gst-1.0/Gst-1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <PackageId>GirCore.Gst-1.0</PackageId>
     <RootNamespace>Gst</RootNamespace>
@@ -7,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\GLib-2.0\GLib-2.0.csproj" />
     <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Libs/Gst-1.0/Public/Module.cs
+++ b/src/Libs/Gst-1.0/Public/Module.cs
@@ -10,6 +10,7 @@ public class Module
             return;
 
         GObject.Module.Initialize();
+        GLib.Module.Initialize();
 
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();

--- a/src/Libs/GstAudio-1.0/GstAudio-1.0.csproj
+++ b/src/Libs/GstAudio-1.0/GstAudio-1.0.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
-    <ProjectReference Include="..\Gst-1.0\Gst-1.0.csproj" />
-    <ProjectReference Include="..\GstBase-1.0\GstBase-1.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.GstAudio-1.0</PackageId>
     <RootNamespace>GstAudio</RootNamespace>
     <Description>C# bindings for GStreamer.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
+    <ProjectReference Include="..\GLib-2.0\GLib-2.0.csproj" />
+    <ProjectReference Include="..\Gst-1.0\Gst-1.0.csproj" />
+    <ProjectReference Include="..\GstBase-1.0\GstBase-1.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/GstAudio-1.0/Public/Module.cs
+++ b/src/Libs/GstAudio-1.0/Public/Module.cs
@@ -9,6 +9,11 @@ public class Module
         if (IsInitialized)
             return;
 
+        GObject.Module.Initialize();
+        GLib.Module.Initialize();
+        Gst.Module.Initialize();
+        GstBase.Module.Initialize();
+
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();
 

--- a/src/Libs/GstBase-1.0/GstBase-1.0.csproj
+++ b/src/Libs/GstBase-1.0/GstBase-1.0.csproj
@@ -1,14 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>GirCore.GstBase-1.0</PackageId>
+    <RootNamespace>GstBase</RootNamespace>
+    <Description>C# bindings for GStreamer.</Description>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\GLib-2.0\GLib-2.0.csproj" />
     <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
     <ProjectReference Include="..\Gst-1.0\Gst-1.0.csproj" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>GirCore.GstBase-1.0</PackageId>
-    <RootNamespace>GstBase</RootNamespace>
-    <Description>C# bindings for GStreamer.</Description>
-  </PropertyGroup>
 </Project>

--- a/src/Libs/GstBase-1.0/Public/Module.cs
+++ b/src/Libs/GstBase-1.0/Public/Module.cs
@@ -9,6 +9,10 @@ public class Module
         if (IsInitialized)
             return;
 
+        GObject.Module.Initialize();
+        GLib.Module.Initialize();
+        Gst.Module.Initialize();
+
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();
 

--- a/src/Libs/GstPbutils-1.0/GstPbutils-1.0.csproj
+++ b/src/Libs/GstPbutils-1.0/GstPbutils-1.0.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
     <ProjectReference Include="..\Gst-1.0\Gst-1.0.csproj" />
     <ProjectReference Include="..\GstAudio-1.0\GstAudio-1.0.csproj" />
     <ProjectReference Include="..\GstBase-1.0\GstBase-1.0.csproj" />

--- a/src/Libs/GstPbutils-1.0/Public/Module.cs
+++ b/src/Libs/GstPbutils-1.0/Public/Module.cs
@@ -9,6 +9,11 @@ public class Module
         if (IsInitialized)
             return;
 
+        Gst.Module.Initialize();
+        GstBase.Module.Initialize();
+        GstAudio.Module.Initialize();
+        GstVideo.Module.Initialize();
+
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();
 

--- a/src/Libs/GstVideo-1.0/GstVideo-1.0.csproj
+++ b/src/Libs/GstVideo-1.0/GstVideo-1.0.csproj
@@ -1,15 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <ProjectReference Include="..\GLib-2.0\GLib-2.0.csproj" />
-    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
-    <ProjectReference Include="..\Gst-1.0\Gst-1.0.csproj" />
-    <ProjectReference Include="..\GstBase-1.0\GstBase-1.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.GstVideo-1.0</PackageId>
     <RootNamespace>GstVideo</RootNamespace>
     <Description>C# bindings for GStreamer.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Gst-1.0\Gst-1.0.csproj" />
+    <ProjectReference Include="..\GstBase-1.0\GstBase-1.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/GstVideo-1.0/Public/Module.cs
+++ b/src/Libs/GstVideo-1.0/Public/Module.cs
@@ -9,6 +9,9 @@ public class Module
         if (IsInitialized)
             return;
 
+        Gst.Module.Initialize();
+        GstBase.Module.Initialize();
+
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();
 

--- a/src/Libs/Gtk-4.0/Gtk-4.0.csproj
+++ b/src/Libs/Gtk-4.0/Gtk-4.0.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\Gdk-4.0\Gdk-4.0.csproj" />
-    <ProjectReference Include="..\Gsk-4.0\Gsk-4.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.Gtk-4.0</PackageId>
     <RootNamespace>Gtk</RootNamespace>
     <Description>C# bindings for Gtk.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Gdk-4.0\Gdk-4.0.csproj" />
+    <ProjectReference Include="..\Gsk-4.0\Gsk-4.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/Gtk-4.0/Public/Module.cs
+++ b/src/Libs/Gtk-4.0/Public/Module.cs
@@ -9,10 +9,8 @@ public class Module
         if (IsInitialized)
             return;
 
-        Gio.Module.Initialize();
-        GdkPixbuf.Module.Initialize();
         Gdk.Module.Initialize();
-        Cairo.Module.Initialize();
+        Gsk.Module.Initialize();
 
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();

--- a/src/Libs/GtkSource-5/GtkSource-5.csproj
+++ b/src/Libs/GtkSource-5/GtkSource-5.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\Gtk-4.0\Gtk-4.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.GtkSource-5</PackageId>
     <RootNamespace>GtkSource</RootNamespace>
     <Description>C# bindings for GtkSourceView.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Gtk-4.0\Gtk-4.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/HarfBuzz-0.0/HarfBuzz-0.0.csproj
+++ b/src/Libs/HarfBuzz-0.0/HarfBuzz-0.0.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\freetype2-2.0\freetype2-2.0.csproj" />
-    <ProjectReference Include="..\GLib-2.0\GLib-2.0.csproj" />
-    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
-  </ItemGroup>
-  
   <PropertyGroup>
     <PackageId>GirCore.HarfBuzz-0.0</PackageId>
     <RootNamespace>HarfBuzz</RootNamespace>
     <Description>C# bindings for HarfBuzz.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\freetype2-2.0\freetype2-2.0.csproj" />
+    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/HarfBuzz-0.0/Public/Module.cs
+++ b/src/Libs/HarfBuzz-0.0/Public/Module.cs
@@ -9,6 +9,8 @@ public class Module
         if (IsInitialized)
             return;
 
+        GObject.Module.Initialize();
+
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();
 

--- a/src/Libs/JavaScriptCore-5.0/JavaScriptCore-5.0.csproj
+++ b/src/Libs/JavaScriptCore-5.0/JavaScriptCore-5.0.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.JavaScriptCore-5.0</PackageId>
     <RootNamespace>JavaScriptCore</RootNamespace>
     <Description>C# bindings for JavaScriptCore.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/Pango-1.0/Pango-1.0.csproj
+++ b/src/Libs/Pango-1.0/Pango-1.0.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\cairo-1.0\cairo-1.0.csproj" />
-    <ProjectReference Include="..\Gio-2.0\Gio-2.0.csproj" />
-    <ProjectReference Include="..\GLib-2.0\GLib-2.0.csproj" />
-    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
-    <ProjectReference Include="..\HarfBuzz-0.0\HarfBuzz-0.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.Pango-1.0</PackageId>
     <RootNamespace>Pango</RootNamespace>
     <Description>C# bindings for Pango.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\cairo-1.0\cairo-1.0.csproj" />
+    <ProjectReference Include="..\Gio-2.0\Gio-2.0.csproj" />
+    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
+    <ProjectReference Include="..\HarfBuzz-0.0\HarfBuzz-0.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/Pango-1.0/Public/Module.cs
+++ b/src/Libs/Pango-1.0/Public/Module.cs
@@ -9,6 +9,11 @@ public class Module
         if (IsInitialized)
             return;
 
+        GObject.Module.Initialize();
+        Gio.Module.Initialize();
+        Cairo.Module.Initialize();
+        HarfBuzz.Module.Initialize();
+
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();
 

--- a/src/Libs/PangoCairo-1.0/PangoCairo-1.0.csproj
+++ b/src/Libs/PangoCairo-1.0/PangoCairo-1.0.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\cairo-1.0\cairo-1.0.csproj" />
-    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
-    <ProjectReference Include="..\Pango-1.0\Pango-1.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.PangoCairo-1.0</PackageId>
     <RootNamespace>PangoCairo</RootNamespace>
     <Description>C# bindings for PangoCairo.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\cairo-1.0\cairo-1.0.csproj" />
+    <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
+    <ProjectReference Include="..\Pango-1.0\Pango-1.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/PangoCairo-1.0/Public/Module.cs
+++ b/src/Libs/PangoCairo-1.0/Public/Module.cs
@@ -9,6 +9,10 @@ public class Module
         if (IsInitialized)
             return;
 
+        GObject.Module.Initialize();
+        Cairo.Module.Initialize();
+        Pango.Module.Initialize();
+
         Internal.ImportResolver.RegisterAsDllImportResolver();
         Internal.TypeRegistration.RegisterTypes();
 

--- a/src/Libs/Soup-3.0/Soup-3.0.csproj
+++ b/src/Libs/Soup-3.0/Soup-3.0.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\Gio-2.0\Gio-2.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.Soup-3.0</PackageId>
     <RootNamespace>Soup</RootNamespace>
     <Description>C# bindings for Soup.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Gio-2.0\Gio-2.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/WebKit2-5.0/WebKit2-5.0.csproj
+++ b/src/Libs/WebKit2-5.0/WebKit2-5.0.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\Gtk-4.0\Gtk-4.0.csproj" />
-    <ProjectReference Include="..\JavaScriptCore-5.0\JavaScriptCore-5.0.csproj" />
-    <ProjectReference Include="..\Soup-3.0\Soup-3.0.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>GirCore.WebKit2-5.0</PackageId>
     <RootNamespace>WebKit2</RootNamespace>
     <Description>C# bindings for WebKit2.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Gtk-4.0\Gtk-4.0.csproj" />
+    <ProjectReference Include="..\JavaScriptCore-5.0\JavaScriptCore-5.0.csproj" />
+    <ProjectReference Include="..\Soup-3.0\Soup-3.0.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Libs/cairo-1.0/cairo-1.0.csproj
+++ b/src/Libs/cairo-1.0/cairo-1.0.csproj
@@ -5,8 +5,8 @@
     <Description>C# bindings for cairo.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\GLib-2.0\GLib-2.0.csproj" />
     <ProjectReference Include="..\GObject-2.0\GObject-2.0.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There are still some discrepancies between gir and csproj files, documented below. This changeset also normalize the format of csproj files moving metadata to the top and dependencies to the bottom.

Adw-1
- gir does not include GObject

cairo-1.0
- gir does not include GObject
- gir does not include GLib

freetype2-2.0
- gir does not include GObject
- gir does not include GLib
- Module.cs is missing

Gdk-4.0
- gir does not include GObject

GdkPixbuf-2.0
- gir does not include GObject
- gir includes GModule (that cannot be included by csproj)

Gst-1.0
- gir includes GModule (that cannot be included by csproj)

GstAudio-1.0
- gir includes GModule (that cannot be included by csproj)

GstBase-1.0
- gir includes GModule (that cannot be included by csproj)

GstPbutils-1.0
- gir does not include GObject

GstVideo-1.0
- gir does not include GObject

 I agree that my contribution may be licensed either under MIT or any version of LGPL license.
