### PR TITLE
Generalize GLib pointer array handling

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/Parameter/Converter/PointerGLibPtrArray.cs
+++ b/src/Generation/Generator/Renderer/Internal/Parameter/Converter/PointerGLibPtrArray.cs
@@ -4,7 +4,7 @@ public class PointerGLibPtrArray : ParameterConverter
 {
     public bool Supports(GirModel.AnyType anyType)
     {
-        return anyType.IsGLibPtrArray<GirModel.Pointer>();
+        return anyType.IsGLibPtrArray();
     }
 
     public RenderableParameter Convert(GirModel.Parameter parameter)

--- a/src/Generation/GirModel/AnyType.cs
+++ b/src/Generation/GirModel/AnyType.cs
@@ -10,6 +10,10 @@ public static class AnyTypeExtension
            && arrayType is GirModel.StandardArrayType
            && arrayType.AnyType.Is<T>();
 
+    public static bool IsGLibPtrArray(this GirModel.AnyType anyType)
+        => anyType.TryPickT1(out var arrayType, out _)
+           && arrayType is GirModel.PointerArrayType;
+
     public static bool IsGLibPtrArray<T>(this GirModel.AnyType anyType) where T : GirModel.Type
         => anyType.TryPickT1(out var arrayType, out _)
            && arrayType is GirModel.PointerArrayType


### PR DESCRIPTION
The generic parameter is not needed as the content of the array is not relevant as long as it is rendered as IntPtr. As there are GLib pointer arrays with types different from GirModel.Pointer this adds support for those cases, too.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
