### PR TITLE
Workaround record array problem

### DIFF
--- a/src/Generation/Generator/Renderer/Public/Parameter/Converter/RecordArray.cs
+++ b/src/Generation/Generator/Renderer/Public/Parameter/Converter/RecordArray.cs
@@ -24,7 +24,7 @@ internal class RecordArray : ParameterConverter
     private static string GetDirection(GirModel.Parameter parameter) => parameter switch
     {
         { Direction: GirModel.Direction.InOut } => ParameterDirection.Ref(),
-        { Direction: GirModel.Direction.Out, CallerAllocates: true } => ParameterDirection.Ref(),
+        { Direction: GirModel.Direction.Out, CallerAllocates: true } => ParameterDirection.In(),
         { Direction: GirModel.Direction.Out } => ParameterDirection.Out(),
         _ => ParameterDirection.In()
     };


### PR DESCRIPTION
The current code for record arrays is not really usable as the GetDirection method can return "ref" / "out" keywords which is not useful in context of native interop.

As HarfBuzz added a function containing a caller allocated out record this case is treated as a regular array to avoid compilation errors. During runtime this is expected to fail but was not working before either.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
