### PR TITLE
Add manual bindings for async functions

### DIFF
--- a/src/Libs/Gtk-4.0/Public/FileDialog.cs
+++ b/src/Libs/Gtk-4.0/Public/FileDialog.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Gtk;
+
+public partial class FileDialog
+{
+    //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
+    public Task<Gio.File?> OpenAsync(Window parent)
+    {
+        var tcs = new TaskCompletionSource<Gio.File?>();
+
+        void Callback(IntPtr sourceObject, IntPtr res, IntPtr userData)
+        {
+            var fileValue = Internal.FileDialog.OpenFinish(sourceObject, res, out var error);
+            GLib.Error.ThrowOnError(error);
+
+            if (fileValue == IntPtr.Zero)
+            {
+                tcs.SetResult(null);
+            }
+            else
+            {
+                var value = new Gio.FileHelper(fileValue, true);
+                tcs.SetResult(value);
+            }
+        }
+
+        Internal.FileDialog.Open(
+            self: Handle,
+            parent: parent.Handle,
+            cancellable: IntPtr.Zero,
+            callback: Callback,
+            userData: IntPtr.Zero
+        );
+
+        return tcs.Task;
+    }
+
+    //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
+    public Task<Gio.File?> SaveAsync(Window parent)
+    {
+        var tcs = new TaskCompletionSource<Gio.File?>();
+
+        void Callback(IntPtr sourceObject, IntPtr res, IntPtr userData)
+        {
+            var fileValue = Internal.FileDialog.SaveFinish(sourceObject, res, out var error);
+            GLib.Error.ThrowOnError(error);
+
+            if (fileValue == IntPtr.Zero)
+            {
+                tcs.SetResult(null);
+            }
+            else
+            {
+                var value = new Gio.FileHelper(fileValue, true);
+                tcs.SetResult(value);
+            }
+        }
+
+        Internal.FileDialog.Save(
+            self: Handle,
+            parent: parent.Handle,
+            cancellable: IntPtr.Zero,
+            callback: Callback,
+            userData: IntPtr.Zero
+        );
+
+        return tcs.Task;
+    }
+
+
+    //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
+    public Task<Gio.File?> SelectFolderAsync(Window parent)
+    {
+        var tcs = new TaskCompletionSource<Gio.File?>();
+
+        void Callback(IntPtr sourceObject, IntPtr res, IntPtr userData)
+        {
+            var fileValue = Internal.FileDialog.SelectFolderFinish(sourceObject, res, out var error);
+            GLib.Error.ThrowOnError(error);
+
+            if (fileValue == IntPtr.Zero)
+            {
+                tcs.SetResult(null);
+            }
+            else
+            {
+                var value = new Gio.FileHelper(fileValue, true);
+                tcs.SetResult(value);
+            }
+        }
+
+        Internal.FileDialog.SelectFolder(
+            self: Handle,
+            parent: parent.Handle,
+            cancellable: IntPtr.Zero,
+            callback: Callback,
+            userData: IntPtr.Zero
+        );
+
+        return tcs.Task;
+    }
+}

--- a/src/Libs/Gtk-4.0/Public/FileLauncher.cs
+++ b/src/Libs/Gtk-4.0/Public/FileLauncher.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Gtk;
+
+public partial class FileLauncher
+{
+    //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
+    public Task<bool> LaunchAsync(Window parent)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+
+        void Callback(IntPtr sourceObject, IntPtr res, IntPtr userData)
+        {
+            var launchValue = Internal.FileLauncher.LaunchFinish(sourceObject, res, out var error);
+            GLib.Error.ThrowOnError(error);
+
+            tcs.SetResult(launchValue);
+        }
+
+        Internal.FileLauncher.Launch(
+            self: Handle,
+            parent: parent.Handle,
+            cancellable: IntPtr.Zero,
+            callback: Callback,
+            userData: IntPtr.Zero
+        );
+
+        return tcs.Task;
+    }
+
+    //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
+    public Task<bool> OpenContainingFolderAsync(Window parent)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+
+        void Callback(IntPtr sourceObject, IntPtr res, IntPtr userData)
+        {
+            var launchValue = Internal.FileLauncher.OpenContainingFolderFinish(sourceObject, res, out var error);
+            GLib.Error.ThrowOnError(error);
+
+            tcs.SetResult(launchValue);
+        }
+
+        Internal.FileLauncher.OpenContainingFolder(
+            self: Handle,
+            parent: parent.Handle,
+            cancellable: IntPtr.Zero,
+            callback: Callback,
+            userData: IntPtr.Zero
+        );
+
+        return tcs.Task;
+    }
+}

--- a/src/Libs/Gtk-4.0/Public/UriLauncher.cs
+++ b/src/Libs/Gtk-4.0/Public/UriLauncher.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Gtk;
+
+public partial class UriLauncher
+{
+    //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
+    public Task<bool> LaunchAsync(Window parent)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+
+        void Callback(IntPtr sourceObject, IntPtr res, IntPtr userData)
+        {
+            var launchValue = Internal.UriLauncher.LaunchFinish(sourceObject, res, out var error);
+            GLib.Error.ThrowOnError(error);
+
+            tcs.SetResult(launchValue);
+        }
+
+        Internal.UriLauncher.Launch(
+            self: Handle,
+            parent: parent.Handle,
+            cancellable: IntPtr.Zero,
+            callback: Callback,
+            userData: IntPtr.Zero
+        );
+
+        return tcs.Task;
+    }
+}


### PR DESCRIPTION
- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

Added:
- Gtk.FileDialog.OpenAsync
- Gtk.FileDialog.SaveAsync
- Gtk.FileDialog.SelectFolderAsync
- Gtk.FileLauncher.LaunchAsync
- Gtk.FileLauncher.OpenContainingFolderAsync
- Gtk.UriLauncher.LaunchAsync

~~I don't think that throwing an exception on error like it's done in [`WebView`](https://github.com/gircore/gir.core/blob/main/src/Libs/WebKit-6.0/Public/WebView.cs) is desired behavior, error is set even if a dialog was simply cancelled by the user, which is definitely not a critical error and I think just checking for `null`/`false` makes more sense:~~

Related: #900 