### PR TITLE
Add missing inheritence from Test class

### DIFF
--- a/src/Tests/Libs/GirTest-0.1.Tests/AliasTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/AliasTest.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GirTest.Tests;
 
 [TestClass, TestCategory("BindingTest")]
-public class AliasTest
+public class AliasTest : Test
 {
     [TestMethod]
     public void CanBeCastedExplicitlyToBaseType()

--- a/src/Tests/Libs/GirTest-0.1.Tests/BitfieldTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/BitfieldTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GirTest.Tests;
 
 [TestClass, TestCategory("BindingTest")]
-public class BitfieldTest
+public class BitfieldTest : Test
 {
     [TestMethod]
     public void SupportsPointedBitfields()

--- a/src/Tests/Libs/GirTest-0.1.Tests/ByteArrayTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/ByteArrayTest.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GirTest.Tests;
 
 [TestClass, TestCategory("BindingTest")]
-public class ByteArrayTest
+public class ByteArrayTest : Test
 {
     private const byte Byte0 = 0x00;
     private const byte Byte1 = 0x11;

--- a/src/Tests/Libs/GirTest-0.1.Tests/IntegerArrayTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/IntegerArrayTest.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace GirTest.Tests;
 
 [TestClass, TestCategory("BindingTest")]
-public class IntegerArrayTest
+public class IntegerArrayTest : Test
 {
     private const int Int0 = 1;
     private const int Int1 = 2;


### PR DESCRIPTION
Inheriting from "Test" ensures that the garbage collector collects all obsolete objects which can reveal memory problems.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
