### PR TITLE
Support array length parameters in public constructors

### DIFF
--- a/src/Generation/Generator/Renderer/Public/Constructor/ConstructorRenderer.cs
+++ b/src/Generation/Generator/Renderer/Public/Constructor/ConstructorRenderer.cs
@@ -70,6 +70,9 @@ public static {newKeyWord}{constructor.Parent.Name}{Nullable.Render(constructor.
             if (parameter.IsDestroyNotify)
                 continue;
 
+            if (parameter.IsArrayLengthParameter)
+                continue;
+
             var typeData = ParameterRenderer.Render(parameter.Parameter);
             result.Add($"{typeData.Direction}{typeData.NullableTypeName} {parameter.GetSignatureName()}");
         }

--- a/src/Libs/GLib-2.0/Public/Bytes.cs
+++ b/src/Libs/GLib-2.0/Public/Bytes.cs
@@ -13,12 +13,6 @@ public sealed partial class Bytes : IDisposable
         GC.AddMemoryPressure(_size);
     }
 
-    public static Bytes New(Span<byte> data)
-    {
-        var obj = new Bytes(Internal.Bytes.New(ref MemoryMarshal.GetReference(data), (nuint) data.Length));
-        return obj;
-    }
-
     public void Dispose()
     {
         Handle.Dispose();

--- a/src/Native/GirTestLib/girtest-byte-array-tester.c
+++ b/src/Native/GirTestLib/girtest-byte-array-tester.c
@@ -26,6 +26,21 @@ girtest_byte_array_tester_class_init(GirTestByteArrayTesterClass *class)
 }
 
 /**
+ * girtest_byte_array_tester_new_from_data:
+ * @buffer: (array length=len): data buffer
+ * @len: The size of the buffer
+ *
+ * This ignores the parameters as it is only there to test code generation data can be ignored.
+ *
+ * Returns: A new instance
+ */
+GirTestByteArrayTester*
+girtest_byte_array_tester_new_from_data(guint8 *buffer, gsize len)
+{
+    return g_object_new (GIRTEST_TYPE_BYTE_ARRAY_TESTER, NULL);
+}
+
+/**
  * girtest_byte_array_tester_data_return:
  *
  * Simple test for an array return value.

--- a/src/Native/GirTestLib/girtest-byte-array-tester.h
+++ b/src/Native/GirTestLib/girtest-byte-array-tester.h
@@ -28,6 +28,7 @@ typedef void (*GirTestByteArrayTesterCallback) (const guchar *buf, gsize count);
  */
 typedef void (*GirTestByteArrayTesterCallbackNoLength) (const guchar *buf);
 
+GirTestByteArrayTester* girtest_byte_array_tester_new_from_data(guint8 *buffer, gsize len);
 const guchar* girtest_byte_array_tester_data_return();
 gssize girtest_byte_array_tester_data_out_caller_allocates(void *buffer, gsize count);
 gsize girtest_byte_array_tester_get_data_size();

--- a/src/Tests/Libs/GirTest-0.1.Tests/ByteArrayTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/ByteArrayTest.cs
@@ -14,6 +14,13 @@ public class ByteArrayTest : Test
     private const nuint DataSize = 3;
 
     [TestMethod]
+    public void SupportsByteArrayWithLengthInConstructor()
+    {
+        var data = new byte[] { 0x01 };
+        _ = ByteArrayTester.NewFromData(data);
+    }
+
+    [TestMethod]
     public void ReturnByteArray()
     {
         var size = ByteArrayTester.GetDataSize();


### PR DESCRIPTION
Supporting array length parameters in public constructors actually means to not render them as they are handled internally.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
