### PR TITLE
Add more manual bindings for async functions

### DIFF
--- a/src/Libs/Gdk-4.0/Public/Clipboard.cs
+++ b/src/Libs/Gdk-4.0/Public/Clipboard.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Gdk;
+
+public partial class Clipboard
+{
+    //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
+    public Task<string?> ReadTextAsync()
+    {
+        var tcs = new TaskCompletionSource<string?>();
+
+        var callbackHandler = new Gio.Internal.AsyncReadyCallbackAsyncHandler((sourceObject, res, data) =>
+        {
+            if (sourceObject is null)
+            {
+                tcs.SetException(new Exception("Missing source object"));
+                return;
+            }
+
+            var readValue = Internal.Clipboard.ReadTextFinish(sourceObject.Handle, res.Handle, out var error);
+
+            if (!error.IsInvalid)
+                tcs.SetException(new GLib.GException(error));
+            else
+                tcs.SetResult(readValue.ConvertToString());
+        });
+
+        Internal.Clipboard.ReadTextAsync(
+            clipboard: Handle,
+            cancellable: IntPtr.Zero,
+            callback: callbackHandler.NativeCallback,
+            userData: IntPtr.Zero
+        );
+
+        return tcs.Task;
+    }
+}

--- a/src/Libs/Gtk-4.0/Public/AlertDialog.cs
+++ b/src/Libs/Gtk-4.0/Public/AlertDialog.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Gtk;
+
+public partial class FileDialog
+{
+    //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
+    public Task<int> ChooseAsync(Window parent)
+    {
+        var tcs = new TaskCompletionSource<int>();
+
+        var callbackHandler = new Gio.Internal.AsyncReadyCallbackAsyncHandler((sourceObject, res, data) =>
+        {
+            if (sourceObject is null)
+            {
+                tcs.SetException(new Exception("Missing source object"));
+                return;
+            }
+
+            var chooseValue = Internal.AlertDialog.ChooseFinish(sourceObject.Handle, res.Handle, out var error);
+
+            if (!error.IsInvalid)
+                tcs.SetException(new GLib.GException(error));
+            else
+                tcs.SetResult(chooseValue);
+        });
+
+        Internal.AlertDialog.Choose(
+            self: Handle,
+            parent: parent.Handle,
+            cancellable: IntPtr.Zero,
+            callback: callbackHandler.NativeCallback,
+            userData: IntPtr.Zero
+        );
+
+        return tcs.Task;
+    }
+}

--- a/src/Libs/Gtk-4.0/Public/FileDialog.cs
+++ b/src/Libs/Gtk-4.0/Public/FileDialog.cs
@@ -40,6 +40,38 @@ public partial class FileDialog
     }
 
     //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
+    public Task<Gio.ListModel?> OpenMultipleAsync(Window parent)
+    {
+        var tcs = new TaskCompletionSource<Gio.ListModel?>();
+
+        var callbackHandler = new Gio.Internal.AsyncReadyCallbackAsyncHandler((sourceObject, res, data) =>
+        {
+            if (sourceObject is null)
+            {
+                tcs.SetException(new Exception("Missing source object"));
+                return;
+            }
+
+            var listValue = Internal.FileDialog.OpenMultipleFinish(sourceObject.Handle, res.Handle, out var error);
+
+            if (!error.IsInvalid)
+                tcs.SetException(new GLib.GException(error));
+            else
+                tcs.SetResult(GObject.Internal.ObjectWrapper.WrapNullableInterfaceHandle<Gio.ListModelHelper>(listValue, true));
+        });
+
+        Internal.FileDialog.OpenMultiple(
+            self: Handle,
+            parent: parent.Handle,
+            cancellable: IntPtr.Zero,
+            callback: callbackHandler.NativeCallback,
+            userData: IntPtr.Zero
+        );
+
+        return tcs.Task;
+    }
+
+    //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
     public Task<Gio.File?> SaveAsync(Window parent)
     {
         var tcs = new TaskCompletionSource<Gio.File?>();
@@ -98,6 +130,38 @@ public partial class FileDialog
         });
 
         Internal.FileDialog.SelectFolder(
+            self: Handle,
+            parent: parent.Handle,
+            cancellable: IntPtr.Zero,
+            callback: callbackHandler.NativeCallback,
+            userData: IntPtr.Zero
+        );
+
+        return tcs.Task;
+    }
+
+    //TODO: Async methods should be generated automatically (https://github.com/gircore/gir.core/issues/893)
+    public Task<Gio.ListModel?> SelectMultipleFoldersAsync(Window parent)
+    {
+        var tcs = new TaskCompletionSource<Gio.ListModel?>();
+
+        var callbackHandler = new Gio.Internal.AsyncReadyCallbackAsyncHandler((sourceObject, res, data) =>
+        {
+            if (sourceObject is null)
+            {
+                tcs.SetException(new Exception("Missing source object"));
+                return;
+            }
+
+            var listValue = Internal.FileDialog.SelectMultipleFoldersFinish(sourceObject.Handle, res.Handle, out var error);
+
+            if (!error.IsInvalid)
+                tcs.SetException(new GLib.GException(error));
+            else
+                tcs.SetResult(GObject.Internal.ObjectWrapper.WrapNullableInterfaceHandle<Gio.ListModelHelper>(listValue, true));
+        });
+
+        Internal.FileDialog.SelectMultipleFolders(
             self: Handle,
             parent: parent.Handle,
             cancellable: IntPtr.Zero,


### PR DESCRIPTION
- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

Added:
* `Gdk.Clipboard.ReadTextAsync`
* `Gtk.AlertDialog.ChooseAsync`
* `Gtk.FileDialog.OpenMultipleAsync`
* `Gtk.FileDialog.SelectMultipleFoldersAsync`

Related: #900