### PR TITLE
Avoid Reflection

### DIFF
--- a/src/Libs/GObject-2.0/Internal/BoxedWrapper.cs
+++ b/src/Libs/GObject-2.0/Internal/BoxedWrapper.cs
@@ -8,34 +8,7 @@ public class BoxedWrapper
 {
     public static object WrapHandle(IntPtr handle, bool ownsHandle, Type gtype)
     {
-        System.Type trueType = TypeDictionary.GetSystemType(gtype);
-
-        if (handle == IntPtr.Zero)
-            throw new NullReferenceException($"Failed to wrap handle as type <{trueType}>. Null handle passed to WrapHandle.");
-
-        // Get constructor for the true type
-        var ctr = GetBoxedConstructor(trueType);
-
-        if (ctr is null)
-            throw new Exception($"Type {trueType} does not define an IntPtr constructor. This could mean improperly defined bindings");
-
-        var result = ctr.Invoke(new object[] { handle, ownsHandle });
-
-        if (result == null)
-            throw new Exception($"Type {trueType}'s factory method returned a null object. This could mean improperly defined bindings");
-
-        return result;
-    }
-
-    private static ConstructorInfo? GetBoxedConstructor(System.Type type)
-    {
-        // Create using 'IntPtr, ownsHandle' constructor
-        ConstructorInfo? ctor = type.GetConstructor(
-            System.Reflection.BindingFlags.NonPublic
-            | System.Reflection.BindingFlags.Public
-            | System.Reflection.BindingFlags.Instance,
-            null, new[] { typeof(IntPtr), typeof(bool) }, null
-        );
-        return ctor;
+        //TODO: REMOVE BOXED WRAPPER
+        return InstanceFactory.Create(handle, ownsHandle);
     }
 }

--- a/src/Libs/GObject-2.0/Internal/DemoTypeRegistration.cs
+++ b/src/Libs/GObject-2.0/Internal/DemoTypeRegistration.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
+
+namespace GObject.Internal;
+
+internal class DemoTypeRegistration
+{
+    internal static void RegisterTypes()
+    {
+        Register<GObject.Binding>(Binding.GetGType, OSPlatform.Linux, OSPlatform.OSX, OSPlatform.Windows);
+    }
+
+    private static void Register<T>(Func<nuint> getType, params OSPlatform[] supportedPlatforms) where T : Constructable
+    {
+        try
+        {
+            if (supportedPlatforms.Any(RuntimeInformation.IsOSPlatform))
+                InstanceFactory.AddFactoryForType(getType(), T.Create);
+        }
+        catch (System.Exception e)
+        {
+            Debug.WriteLine($"Could not register type '{nameof(T)}': {e.Message}");
+        }
+    }
+}

--- a/src/Libs/GObject-2.0/Internal/InstanceFactory.cs
+++ b/src/Libs/GObject-2.0/Internal/InstanceFactory.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace GObject.Internal;
+
+public interface Constructable
+{
+    public static abstract object Create(IntPtr handle, bool ownedRef);
+}
+
+/// <summary>
+/// Creates new instances of classes and records
+/// </summary>
+internal class InstanceFactory
+{
+    private static readonly Dictionary<Type, Func<IntPtr, bool, object>> Factories = new();
+    
+    public static object Create(IntPtr handle, bool ownedRef)
+    {
+        var gtype = GetTypeFromInstance(handle);
+        
+        Debug.Assert(
+            condition: Functions.TypeName(gtype.Value).ConvertToString() == Functions.TypeNameFromInstance(new TypeInstanceUnownedHandle(handle)).ConvertToString(),
+            message: "GType name of instance and class do not match"
+        );
+
+        var factory = GetFactory(gtype);
+        
+        return factory(handle, ownedRef);
+    }
+
+    public static void AddFactoryForType(Type type, Func<IntPtr, bool, object> factory)
+    {
+        Factories[type] = factory;
+    }
+    
+    private static Func<IntPtr, bool, object> GetFactory(Type gtype)
+    {
+        if (Factories.TryGetValue(gtype, out var factory))
+            return factory;
+
+        do
+        {
+            var parentType = new Type(Functions.TypeParent(gtype));
+            if (parentType.Value is (nuint) BasicType.Invalid or (nuint) BasicType.None)
+                throw new Exception("Could not retrieve parent type - is the typeid valid?");
+
+            if (!Factories.TryGetValue(gtype, out var parentFactory))
+                continue;
+
+            //Store parent factory for later use
+            AddFactoryForType(gtype, parentFactory);
+
+        } while(true);
+    }
+    
+    private static unsafe Type GetTypeFromInstance(IntPtr handle)
+    {
+        var gclass = Unsafe.AsRef<TypeInstanceData>((void*) handle).GClass;
+        var gtype = Unsafe.AsRef<TypeClassData>((void*) gclass).GType;
+
+        if (gtype == 0)
+            throw new Exception("Could not retrieve type from class struct - is the struct valid?");
+
+        return new Type(gtype);
+    }
+}

--- a/src/Libs/GObject-2.0/Internal/TypeDictionary.cs
+++ b/src/Libs/GObject-2.0/Internal/TypeDictionary.cs
@@ -47,7 +47,6 @@ public enum BasicType
 public static class TypeDictionary
 {
     private static readonly Dictionary<System.Type, Type> _systemTypeDict = new();
-    private static readonly Dictionary<Type, System.Type> _reverseTypeDict = new();
 
     /// <summary>
     /// Add a new mapping of (System.Type, GObject.Type) to the type dictionary. 
@@ -63,7 +62,6 @@ public static class TypeDictionary
         );
 
         _systemTypeDict[systemType] = type;
-        _reverseTypeDict[type] = systemType;
     }
 
     /// <summary>
@@ -87,39 +85,7 @@ public static class TypeDictionary
         return _systemTypeDict[type];
     }
 
-    /// <summary>
-    /// For a given gtype, retrieve the corresponding managed type.  
-    /// </summary>
-    /// <param name="gtype">A type from the GType type system</param>
-    /// <returns>The equivalent managed type</returns>
-    internal static System.Type GetSystemType(Type gtype)
-    {
-        if (_reverseTypeDict.TryGetValue(gtype, out System.Type? sysType))
-            return sysType;
-
-        // If gtype is not in the type dictionary, walk up the
-        // tree until we find a type that is. As all objects are
-        // descended from GObject, we will eventually find a parent
-        // type that is registered.
-
-        while (!_reverseTypeDict.TryGetValue(gtype, out sysType))
-        {
-            gtype = new Type(Functions.TypeParent(gtype.Value));
-            if (gtype.Value == (nuint) BasicType.Invalid ||
-                gtype.Value == (nuint) BasicType.None)
-                throw new Exception("Could not retrieve parent type - is the typeid valid?");
-        }
-
-        // Store for future lookups
-        _reverseTypeDict[gtype] = sysType;
-
-        return sysType;
-    }
-
     // These may be unneeded - keep for now 
-    internal static bool ContainsGType(Type gtype)
-        => _reverseTypeDict.ContainsKey(gtype);
-
     internal static bool ContainsSystemType(System.Type type)
         => _systemTypeDict.ContainsKey(type);
 }


### PR DESCRIPTION
- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

Fixes: #397, #919

**Before working on this there should probably be a PR which introduces a new way of registering classes and subclasses. Additionally there should be a source generator which uses this way to register the types and subclasses with the existing TypeDictionary. Subclasses can be registered in their static constructor as they can't be created by GObject before they were used in c#. If this is done there can be work done to remove reflection and the TypeDictionary. In this PR.**

Todo:
- [ ] Ensure that classes and subclass can be created with their own gtype.
- [ ] Allow users to Register their subclasses manually so all types are known to the typesystem
- [ ] Create SourceGenerator to automatically register all subclasses (optional)
- [ ] Find a way to remove the TypeDictionary and pass on the GType through constructor chain if a subclass is instantiated manually thus avoiding the lookup in the type dictionary
- [ ] Make sure that it is possible to get an instance of a subclass even if the metod returns a GObject.Object