### PR TITLE
ToggleRef: Remove toggle ref on main context

### DIFF
--- a/src/Libs/GObject-2.0/Internal/ObjectMapper.ToggleRef.cs
+++ b/src/Libs/GObject-2.0/Internal/ObjectMapper.ToggleRef.cs
@@ -89,7 +89,12 @@ public partial class ObjectMapper
 
         public void Dispose()
         {
-            Internal.Object.RemoveToggleRef(_handle, _callback, IntPtr.Zero);
+            var sourceFunc = new GLib.Internal.SourceFuncAsyncHandler(() =>
+            {
+                Internal.Object.RemoveToggleRef(_handle, _callback, IntPtr.Zero);
+                return false;
+            });
+            GLib.Internal.MainContext.Invoke(GLib.Internal.MainContextUnownedHandle.NullHandle, sourceFunc.NativeCallback, IntPtr.Zero);
         }
     }
 }


### PR DESCRIPTION
- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

RemoveToggleRef is not guaranteed to be thread safe as it is unknown what happens on the final object disposal (dependeing on the library using GObject).

As the dotnet GC is collecting it's garbage in a separate thread this can lead to side effects like the one described in #1044 where GTK is requiring the object disposal to happen on the main thread.

To fix this object disposal is tunneled through the main context of GLib.