### PR TITLE
Remove duplicate semicolon in return statements

### DIFF
--- a/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/ForeignTypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/ForeignTypedRecord.cs
@@ -22,7 +22,7 @@ internal class ForeignTypedRecord : ReturnTypeConverter
         var createNewInstance = $"new {Model.ComplexType.GetFullyQualified(record)}({handleExpression})";
 
         return returnType.Nullable
-            ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance};"
+            ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance}"
             : createNewInstance;
     }
 }

--- a/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/Interface.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/Interface.cs
@@ -17,6 +17,6 @@ internal class Interface : ReturnTypeConverter
 
         return returnType.Nullable
             ? $"GObject.Internal.ObjectWrapper.WrapNullableInterfaceHandle<{Model.Interface.GetFullyQualifiedImplementationName(@interface)}>({fromVariableName}, {Transfer.IsOwnedRef(returnType.Transfer).ToString().ToLower()})"
-            : $"GObject.Internal.ObjectWrapper.WrapInterfaceHandle<{Model.Interface.GetFullyQualifiedImplementationName(@interface)}>({fromVariableName}, {Transfer.IsOwnedRef(returnType.Transfer).ToString().ToLower()})"; ;
+            : $"GObject.Internal.ObjectWrapper.WrapInterfaceHandle<{Model.Interface.GetFullyQualifiedImplementationName(@interface)}>({fromVariableName}, {Transfer.IsOwnedRef(returnType.Transfer).ToString().ToLower()})";
     }
 }

--- a/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/OpaqueTypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/OpaqueTypedRecord.cs
@@ -22,7 +22,7 @@ internal class OpaqueTypedRecord : ReturnTypeConverter
         var createNewInstance = $"new {Model.ComplexType.GetFullyQualified(record)}({handleExpression})";
 
         return returnType.Nullable
-            ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance};"
+            ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance}"
             : createNewInstance;
     }
 }

--- a/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/OpaqueUntypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/OpaqueUntypedRecord.cs
@@ -22,7 +22,7 @@ internal class OpaqueUntypedRecord : ReturnTypeConverter
         var createNewInstance = $"new {Model.ComplexType.GetFullyQualified(record)}({handleExpression})";
 
         return returnType.Nullable
-            ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance};"
+            ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance}"
             : createNewInstance;
     }
 }

--- a/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/TypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/TypedRecord.cs
@@ -22,7 +22,7 @@ internal class TypedRecord : ReturnTypeConverter
         var createNewInstance = $"new {Model.ComplexType.GetFullyQualified(record)}({handleExpression})";
 
         return returnType.Nullable
-            ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance};"
+            ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance}"
             : createNewInstance;
     }
 }

--- a/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/UntypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/UntypedRecord.cs
@@ -22,7 +22,7 @@ internal class UntypedRecord : ReturnTypeConverter
         var createNewInstance = $"new {Model.ComplexType.GetFullyQualified(record)}({handleExpression})";
 
         return returnType.Nullable
-            ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance};"
+            ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance}"
             : createNewInstance;
     }
 }


### PR DESCRIPTION
- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

This is a minor tidy up to the generated code. Some of the expressions returned from `ReturnTypeConverter` implementations added a semicolon, but a semicolon is already added everywhere `ReturnTypeToManagedExpression.Render` is called.

This didn't cause any build failures but Rider would show red lines when viewing the generated code and complain about "unreachable code", referring to the empty statement before the second semicolon.