### PR TITLE
Map "gssize" to native integers

### DIFF
--- a/src/Generation/Generator/Model/Type.cs
+++ b/src/Generation/Generator/Model/Type.cs
@@ -25,6 +25,7 @@ internal static class Type
             GirModel.Byte => "byte",
             GirModel.Bool => "bool",
             GirModel.Void => "void",
+            GirModel.NativeInteger => "nint",
             GirModel.NativeUnsignedInteger => "nuint",
             GirModel.Pointer => Pointer,
             GirModel.UnsignedPointer => "UIntPtr",

--- a/src/Generation/Generator/Renderer/Public/Constant/Converter/PrimitiveValueType.cs
+++ b/src/Generation/Generator/Renderer/Public/Constant/Converter/PrimitiveValueType.cs
@@ -32,6 +32,7 @@ internal class PrimitiveValueType : ConstantsConverter
             GirModel.Double => double.TryParse(constant.Value, out _),
             GirModel.Integer => int.TryParse(constant.Value, out _),
             GirModel.Long => long.TryParse(constant.Value, out _),
+            GirModel.NativeInteger => nint.TryParse(constant.Value, out _),
             GirModel.NativeUnsignedInteger => nuint.TryParse(constant.Value, out _),
             GirModel.Short => short.TryParse(constant.Value, out _),
             GirModel.SignedByte => sbyte.TryParse(constant.Value, out _),

--- a/src/Generation/Generator/Renderer/Public/Constant/Converter/PrimitiveValueTypeAlias.cs
+++ b/src/Generation/Generator/Renderer/Public/Constant/Converter/PrimitiveValueTypeAlias.cs
@@ -35,6 +35,7 @@ internal class PrimitiveValueTypeAlias : ConstantsConverter
             GirModel.Double => double.TryParse(constant.Value, out _),
             GirModel.Integer => int.TryParse(constant.Value, out _),
             GirModel.Long => long.TryParse(constant.Value, out _),
+            GirModel.NativeInteger => nint.TryParse(constant.Value, out _),
             GirModel.NativeUnsignedInteger => nuint.TryParse(constant.Value, out _),
             GirModel.Short => short.TryParse(constant.Value, out _),
             GirModel.SignedByte => sbyte.TryParse(constant.Value, out _),

--- a/src/Generation/GirLoader/Output/NativeInteger.cs
+++ b/src/Generation/GirLoader/Output/NativeInteger.cs
@@ -1,0 +1,6 @@
+﻿namespace GirLoader.Output;
+
+public class NativeInteger : PrimitiveValueType, GirModel.NativeInteger
+{
+    public NativeInteger(string ctype) : base(ctype) { }
+}

--- a/src/Generation/GirLoader/TypeReferenceResolver/TypeReferenceResolver.GlobalTypeCache.cs
+++ b/src/Generation/GirLoader/TypeReferenceResolver/TypeReferenceResolver.GlobalTypeCache.cs
@@ -58,7 +58,7 @@ internal partial class TypeReferenceResolver
             Add(new Output.SignedByte("gint8"));
 
             Add(new Output.Long("glong"));
-            Add(new Output.Long("gssize"));
+            Add(new Output.NativeInteger("gssize"));
             Add(new Output.Long("gint64"));
             Add(new Output.Long("goffset"));
             Add(new Output.Long("time_t"));

--- a/src/Generation/GirModel/NativeInteger.cs
+++ b/src/Generation/GirModel/NativeInteger.cs
@@ -1,0 +1,3 @@
+﻿namespace GirModel;
+
+public interface NativeInteger : PrimitiveValueType { }

--- a/src/Tests/Generation/GirLoader.Tests/ClassPropertyTest.cs
+++ b/src/Tests/Generation/GirLoader.Tests/ClassPropertyTest.cs
@@ -89,7 +89,7 @@ public class ClassPropertyTest
     [DataRow("char", false, typeof(Output.SignedByte))]
     [DataRow("gint8", false, typeof(Output.SignedByte))]
     [DataRow("glong", false, typeof(Output.Long))]
-    [DataRow("gssize", false, typeof(Output.Long))]
+    [DataRow("gssize", false, typeof(Output.NativeInteger))]
     [DataRow("gint64", false, typeof(Output.Long))]
     [DataRow("goffset", false, typeof(Output.Long))]
     [DataRow("time_t", false, typeof(Output.Long))]
@@ -125,7 +125,7 @@ public class ClassPropertyTest
     //[DataRow("char*", true, typeof(Output.Model.String))] -> Ambigous between UTF8 and platform strings
     [DataRow("gint8*", true, typeof(Output.SignedByte))]
     [DataRow("glong*", true, typeof(Output.Long))]
-    [DataRow("gssize*", true, typeof(Output.Long))]
+    [DataRow("gssize*", true, typeof(Output.NativeInteger))]
     [DataRow("gint64*", true, typeof(Output.Long))]
     [DataRow("goffset*", true, typeof(Output.Long))]
     [DataRow("time_t*", true, typeof(Output.Long))]

--- a/src/Tests/Libs/GirTest-0.1.Tests/ByteArrayTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/ByteArrayTest.cs
@@ -42,7 +42,7 @@ public class ByteArrayTest : Test
     {
         var buffer = new byte[5];
         var length = ByteArrayTester.DataOutCallerAllocates(buffer);
-        length.Should().Be((long) DataSize);
+        length.Should().Be((nint) DataSize);
 
         buffer[0].Should().Be(Byte0);
         buffer[1].Should().Be(Byte1);

--- a/src/Tests/Libs/GirTest-0.1.Tests/IntegerArrayTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/IntegerArrayTest.cs
@@ -36,7 +36,7 @@ public class IntegerArrayTest : Test
     {
         var buffer = new int[5];
         var length = IntegerArrayTester.DataOutCallerAllocates(buffer);
-        length.Should().Be((long) DataSize);
+        length.Should().Be((nint) DataSize);
 
         buffer[0].Should().Be(Int0);
         buffer[1].Should().Be(Int1);


### PR DESCRIPTION
The GObject type "gssize" (sgined "gsize") was mapped to "long". Which is wrong, as "gssize" is dependent if the system is a 64 bit / 32 bit host. This maps "gssize" to "nint", similarly to "gsize" which is already mapped to "nuint".

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
