### PR TITLE
Add nullable annotation to nullable string array parameters in internal methods

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/Parameter/Converter/Utf8StringArray.cs
+++ b/src/Generation/Generator/Renderer/Internal/Parameter/Converter/Utf8StringArray.cs
@@ -25,11 +25,12 @@ internal class Utf8StringArray : ParameterConverter
     private static RenderableParameter SizeBasedArray(GirModel.Parameter parameter)
     {
         var length = parameter.AnyTypeOrVarArgs.AsT0.AsT1.Length ?? throw new Exception("Length must not be null");
+        var typeName = Model.ArrayType.GetName(parameter.AnyTypeOrVarArgs.AsT0.AsT1) + Nullable.Render(parameter);
 
         return new RenderableParameter(
             Attribute: MarshalAs.UnmanagedLpArray(sizeParamIndex: length),
             Direction: string.Empty,
-            NullableTypeName: Model.ArrayType.GetName(parameter.AnyTypeOrVarArgs.AsT0.AsT1),
+            NullableTypeName: typeName,
             Name: Model.Parameter.GetName(parameter)
         );
     }

--- a/src/Native/GirTestLib/girtest-string-array-tester.c
+++ b/src/Native/GirTestLib/girtest-string-array-tester.c
@@ -111,6 +111,24 @@ gchar* girtest_string_array_tester_utf8_return_element_parameter_null_terminated
 }
 
 /**
+ * girtest_string_array_tester_utf8_return_element_parameter_transfer_none_nullable_with_size:
+ * @data: (array length=data_size) (element-type utf8) (transfer none) (nullable): Array
+ * @data_size: The number of values in @data
+ * @position: The index to return
+ *
+ * Returns the string at the given position.
+ *
+ * Returns: (transfer full) (nullable): The string of the array from the given position
+ */
+gchar* girtest_string_array_tester_utf8_return_element_parameter_transfer_none_nullable_with_size(const gchar** data, int data_size, int position)
+{
+    if(!data)
+        return NULL;
+
+    return g_strdup(data[position]);
+}
+
+/**
  * girtest_string_array_tester_filename_return_element_parameter_null_terminated_transfer_none:
  * @data: (array zero-terminated=1) (element-type filename) (transfer none): Array
  * @position: The index to return

--- a/src/Native/GirTestLib/girtest-string-array-tester.h
+++ b/src/Native/GirTestLib/girtest-string-array-tester.h
@@ -16,5 +16,6 @@ const char** girtest_string_array_tester_filename_return_transfer_none_nullable(
 gchar* girtest_string_array_tester_utf8_return_element_parameter_null_terminated_transfer_none(const gchar** data, int position);
 gchar* girtest_string_array_tester_filename_return_element_parameter_null_terminated_transfer_none(const gchar** data, int position);
 gchar* girtest_string_array_tester_utf8_return_element_parameter_null_terminated_transfer_none_nullable(const gchar** data, int position);
+gchar* girtest_string_array_tester_utf8_return_element_parameter_transfer_none_nullable_with_size(const gchar** data, int data_size, int position);
 gchar* girtest_string_array_tester_filename_return_element_parameter_null_terminated_transfer_none_nullable(const gchar** data, int position);
 G_END_DECLS

--- a/src/Tests/Libs/GirTest-0.1.Tests/StringArrayTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/StringArrayTest.cs
@@ -39,6 +39,15 @@ public class StringArrayTest : Test
     }
 
     [TestMethod]
+    public void Utf8ParameterTransferNoneNullableWithSize()
+    {
+        var array = new[] { "FOO", "BAR" };
+        StringArrayTester.Utf8ReturnElementParameterTransferNoneNullableWithSize(array, 2, 0).Should().Be(array[0]);
+        StringArrayTester.Utf8ReturnElementParameterTransferNoneNullableWithSize(array, 2, 1).Should().Be(array[1]);
+        StringArrayTester.Utf8ReturnElementParameterTransferNoneNullableWithSize(null, 0, 1).Should().BeNull();
+    }
+
+    [TestMethod]
     public void PlatformReturnNullTerminatedStringArrayTransferNone()
     {
         var array = new[] { "FOO", "BAR" };


### PR DESCRIPTION
- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

This fixes #1077

I'm not super familiar with the code so let me know if there's a better way to handle this, or if you'd rather just fix it yourself :smile: 