### PR TITLE
Foreign typed records: Require to implement a handle release manually

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/ForeignTypedRecordHandle.cs
+++ b/src/Generation/Generator/Renderer/Internal/ForeignTypedRecordHandle.cs
@@ -66,7 +66,7 @@ public class {unownedHandleTypeName} : {typeName}
     }}
 }}
 
-public class {ownedHandleTypeName} : {typeName}
+public partial class {ownedHandleTypeName} : {typeName}
 {{
     /// <summary>
     /// Creates a new instance of {ownedHandleTypeName}. Used automatically by PInvoke.
@@ -91,12 +91,6 @@ public class {ownedHandleTypeName} : {typeName}
     {{
         var ownedPtr = GObject.Internal.Functions.BoxedCopy({getGType}, ptr);
         return new {ownedHandleTypeName}(ownedPtr);
-    }}
-
-    protected override bool ReleaseHandle()
-    {{
-        GObject.Internal.Functions.BoxedFree({getGType}, handle);
-        return true;
     }}
 }}";
     }

--- a/src/Libs/cairo-1.0/Internal/ContextHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/ContextHandle.cs
@@ -1,0 +1,10 @@
+﻿namespace Cairo.Internal;
+
+public partial class ContextOwnedHandle
+{
+    protected override bool ReleaseHandle()
+    {
+        Context.Destroy(handle);
+        return true;
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/DeviceHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/DeviceHandle.cs
@@ -1,0 +1,10 @@
+﻿namespace Cairo.Internal;
+
+public partial class DeviceOwnedHandle
+{
+    protected override bool ReleaseHandle()
+    {
+        Device.Destroy(handle);
+        return true;
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/FontFaceHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/FontFaceHandle.cs
@@ -1,0 +1,10 @@
+﻿namespace Cairo.Internal;
+
+public partial class FontFaceOwnedHandle
+{
+    protected override bool ReleaseHandle()
+    {
+        FontFace.Destroy(handle);
+        return true;
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/FontOptionsHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/FontOptionsHandle.cs
@@ -1,0 +1,10 @@
+﻿namespace Cairo.Internal;
+
+public partial class FontOptionsOwnedHandle
+{
+    protected override bool ReleaseHandle()
+    {
+        FontOptions.Destroy(handle);
+        return true;
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/PatternHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/PatternHandle.cs
@@ -1,0 +1,10 @@
+﻿namespace Cairo.Internal;
+
+public partial class PatternOwnedHandle
+{
+    protected override bool ReleaseHandle()
+    {
+        Pattern.Destroy(handle);
+        return true;
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/RegionHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/RegionHandle.cs
@@ -1,0 +1,10 @@
+﻿namespace Cairo.Internal;
+
+public partial class RegionOwnedHandle
+{
+    protected override bool ReleaseHandle()
+    {
+        Region.Destroy(handle);
+        return true;
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/ScaledFontHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/ScaledFontHandle.cs
@@ -1,0 +1,10 @@
+﻿namespace Cairo.Internal;
+
+public partial class ScaledFontOwnedHandle
+{
+    protected override bool ReleaseHandle()
+    {
+        ScaledFont.Destroy(handle);
+        return true;
+    }
+}

--- a/src/Libs/cairo-1.0/Internal/SurfaceHandle.cs
+++ b/src/Libs/cairo-1.0/Internal/SurfaceHandle.cs
@@ -1,0 +1,10 @@
+﻿namespace Cairo.Internal;
+
+public partial class SurfaceOwnedHandle
+{
+    protected override bool ReleaseHandle()
+    {
+        Surface.Destroy(handle);
+        return true;
+    }
+}


### PR DESCRIPTION
As foreign typed records are known to the gobject type system there must be a function available to free the instance. It is preferred to call this function directly as the type system has to do a dictionary lookup each time an instance should be freed.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
