### PR TITLE
GObject.Type: Mark struct as readonly and make it a record

### DIFF
--- a/src/Libs/GLib-2.0/GObject/Public/Type.cs
+++ b/src/Libs/GLib-2.0/GObject/Public/Type.cs
@@ -3,7 +3,7 @@
 namespace GObject;
 
 [StructLayout(LayoutKind.Explicit)]
-public struct Type
+public readonly record struct Type
 {
 
     //This is a manual implementation of GObject.Type inside GLib project inside the GObject namespace.


### PR DESCRIPTION
This improves performance as a generated equality function is used instead of a runtime check and allows for further compiler optimizations.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
