### PR TITLE
Tutorial: Use project reference instead of package reference

### DIFF
--- a/docs/docs/tutorial/gtk/src/BoxLayout/BoxLayout.csproj
+++ b/docs/docs/tutorial/gtk/src/BoxLayout/BoxLayout.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="gircore.gtk-4.0" Version="0.5.0" />
+    <ProjectReference Include="..\..\..\..\..\..\src\Libs\Gtk-4.0\Gtk-4.0.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/docs/tutorial/gtk/src/HelloWorld/HelloWorld.csproj
+++ b/docs/docs/tutorial/gtk/src/HelloWorld/HelloWorld.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="gircore.gtk-4.0" Version="0.5.0" />
+    <ProjectReference Include="..\..\..\..\..\..\src\Libs\Gtk-4.0\Gtk-4.0.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
By using project references it can be ensured that the tutorial code is working with the current code and must not be kept up to date after a version got released.

Fixes: #1145

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
