### PR TITLE
GObject-2.0.Integration: Disable snupk generation

### DIFF
--- a/src/Extensions/GObject-2.0.Integration/GObject-2.0.Integration.csproj
+++ b/src/Extensions/GObject-2.0.Integration/GObject-2.0.Integration.csproj
@@ -13,6 +13,13 @@
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <NoWarn>$(NoWarn);NU5128</NoWarn>
+      
+        <!-- 
+        Disable snupk generation as there are no symbols which results in an error
+        if the empty snupkg file is uploaded to nuget.
+        -->
+        <IncludeSymbols>false</IncludeSymbols>
+        <IncludeSource>false</IncludeSource>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
GObject-2.0.Integration: Disable snupk generation as there are no symbols which results in an error if the empty snupkg file is uploaded to nuget.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
