### PR TITLE
GObject.Object: Make "Dispose" method virtual again

### DIFF
--- a/src/Libs/GObject-2.0/Public/Object.cs
+++ b/src/Libs/GObject-2.0/Public/Object.cs
@@ -16,7 +16,7 @@ public partial class Object : IDisposable
         Handle.AddMemoryPressure();
     }
 
-    public void Dispose()
+    public virtual void Dispose()
     {
         Debug.WriteLine($"Handle {Handle.DangerousGetHandle()}: Disposing object of type {GetType()}.");
         DisposeClosures();

--- a/src/Tests/Libs/GirTest-0.1.Tests/ClassTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/ClassTest.cs
@@ -63,6 +63,12 @@ public class ClassTest : Test
     }
 
     [TestMethod]
+    public void GObjectDisposeMethodIsVirtual()
+    {
+        typeof(GObject.Object).GetMethod(nameof(GObject.Object.Dispose)).Should().BeVirtual();
+    }
+
+    [TestMethod]
     public void TestManualGObjectDisposal()
     {
         var obj = ClassTester.New();


### PR DESCRIPTION
The virtual keyword got lost by accident during the implementation of the new instantiation framework. Custom classes want to be able to plug into the "Dispose" call of GObject.Object otherwise the custom "Dispose" would eventually not be executed if the method is marked with the "new" keyword.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
