### PR TITLE
Null-terminated array by convention

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/ReturnType/Converter/PlatformStringArray.cs
+++ b/src/Generation/Generator/Renderer/Internal/ReturnType/Converter/PlatformStringArray.cs
@@ -11,15 +11,15 @@ internal class PlatformStringArray : ReturnTypeConverter
 
     public RenderableReturnType Convert(GirModel.ReturnType returnType)
     {
-        var arrayType = returnType.AnyType.AsT1;
+        // var arrayType = returnType.AnyType.AsT1;
 
-        if (arrayType.IsZeroTerminated)
+        // if (arrayType.IsZeroTerminated)
             return NullTerminatedArray(returnType);
 
-        if (arrayType.Length is not null)
-            return SizeBasedArray();
+        // if (arrayType.Length is not null)
+        //     return SizeBasedArray();
 
-        throw new Exception("Unknown kind of array");
+        // throw new Exception("Unknown kind of array");
     }
 
     private static RenderableReturnType NullTerminatedArray(GirModel.ReturnType returnType)

--- a/src/Generation/Generator/Renderer/Internal/ReturnType/Converter/Utf8StringArray.cs
+++ b/src/Generation/Generator/Renderer/Internal/ReturnType/Converter/Utf8StringArray.cs
@@ -11,15 +11,15 @@ internal class Utf8StringArray : ReturnTypeConverter
 
     public RenderableReturnType Convert(GirModel.ReturnType returnType)
     {
-        var arrayType = returnType.AnyType.AsT1;
+        // var arrayType = returnType.AnyType.AsT1;
 
-        if (arrayType.IsZeroTerminated)
+        // if (arrayType.IsZeroTerminated)
             return NullTerminatedArray(returnType);
 
-        if (arrayType.Length is not null)
-            return SizeBasedArray();
+        // if (arrayType.Length is not null)
+        //     return SizeBasedArray();
 
-        throw new Exception("Unknown kind of array");
+        // throw new Exception("Unknown kind of array");
     }
 
     private static RenderableReturnType NullTerminatedArray(GirModel.ReturnType returnType)

--- a/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/PlatformStringArray.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/PlatformStringArray.cs
@@ -13,15 +13,15 @@ internal class PlatformStringArray : ReturnTypeConverter
         data.SetExpression(fromVariableName =>
         {
             var returnType = data.ReturnType;
-            var arrayType = returnType.AnyType.AsT1;
+            // var arrayType = returnType.AnyType.AsT1;
 
-            if (arrayType.IsZeroTerminated)
+            // if (arrayType.IsZeroTerminated)
                 return NullTerminatedArray(returnType, fromVariableName);
 
-            if (arrayType.Length is not null)
-                return SizeBasedArray(returnType, fromVariableName);
+            // if (arrayType.Length is not null)
+            //     return SizeBasedArray(returnType, fromVariableName);
 
-            throw new Exception("Unknown kind of array");
+            // throw new Exception("Unknown kind of array");
         });
     }
 

--- a/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/Utf8StringArray.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/Utf8StringArray.cs
@@ -14,14 +14,14 @@ internal class Utf8StringArray : ReturnTypeConverter
         data.SetExpression(fromVariableName =>
         {
             var returnType = data.ReturnType;
-            var arrayType = returnType.AnyType.AsT1;
+            // var arrayType = returnType.AnyType.AsT1;
 
-            if (arrayType.IsZeroTerminated)
+            // if (arrayType.IsZeroTerminated)
                 return NullTerminatedArray(returnType, fromVariableName);
-            if (arrayType.Length is not null)
-                return SizeBasedArray(returnType, fromVariableName);
+            // if (arrayType.Length is not null)
+            //     return SizeBasedArray(returnType, fromVariableName);
 
-            throw new Exception("Unknown kind of array");
+            // throw new Exception("Unknown kind of array");
         });
     }
 


### PR DESCRIPTION
At this moment, the code generated by the API for size-based arrays is not functional.

Arrays used as return values are almost always NULL-terminated. This is not mandatory, but it is the convention. So treating them like NULL-terminated arrays will works like a charm 99% of the time.

See: https://github.com/gircore/gir.core/issues/955#issuecomment-2741510912 for detailed explanation

- [ x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
