### PR TITLE
TypedRecords: Remove public OnDispose method

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/TypedRecordHandle.cs
+++ b/src/Generation/Generator/Renderer/Internal/TypedRecordHandle.cs
@@ -102,7 +102,7 @@ public class {unownedHandleTypeName} : {typeName}
     }}
 }}
 
-public class {ownedHandleTypeName} : {typeName}
+public partial class {ownedHandleTypeName} : {typeName}
 {{
     /// <summary>
     /// Creates a new instance of {ownedHandleTypeName}. Used automatically by PInvoke.
@@ -131,8 +131,11 @@ public class {ownedHandleTypeName} : {typeName}
         return new {ownedHandleTypeName}(ownedPtr);
     }}
 
+    partial void OnReleaseHandle();
+
     protected override bool ReleaseHandle()
     {{
+        OnReleaseHandle();
         {RenderFreeStatement(record, "handle")}
         return true;
     }}

--- a/src/Generation/Generator/Renderer/Public/OpaqueTypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Public/OpaqueTypedRecord.cs
@@ -93,11 +93,8 @@ public sealed partial class {name} : GLib.BoxedRecord, GObject.GTypeProvider, GO
         return Handle.GetHashCode();
     }}
 
-    partial void OnDispose();
-
     public void Dispose()
     {{
-        OnDispose();
         Handle.Dispose();
     }}
 }}";

--- a/src/Generation/Generator/Renderer/Public/TypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Public/TypedRecord.cs
@@ -101,11 +101,8 @@ public sealed partial class {name} : GLib.BoxedRecord, GObject.GTypeProvider, GO
         return Handle.GetHashCode();
     }}
 
-    partial void OnDispose();
-
     public void Dispose()
     {{
-        OnDispose();
         Handle.Dispose();
     }}
 }}";

--- a/src/Libs/GObject-2.0/Internal/ClosureHandle.cs
+++ b/src/Libs/GObject-2.0/Internal/ClosureHandle.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics;
+
+namespace GObject.Internal;
+
+public partial class ClosureOwnedHandle
+{
+    partial void OnReleaseHandle()
+    {
+        Debug.WriteLine($"Closure {DangerousGetHandle()}: Reference will be released.");
+    }
+}

--- a/src/Libs/GObject-2.0/Public/Closure.cs
+++ b/src/Libs/GObject-2.0/Public/Closure.cs
@@ -14,7 +14,7 @@ public partial class Closure
     internal Closure(ClosureCallback callback, Internal.ObjectHandle handle)
     {
         _callback = callback;
-        //The initial state is floating (meaning there is already a ref which is unowned).
+        //The initial state is floating (meaning there is already a ref that is unowned).
         //So we first create an owned copy (to ref the instance), which increases the count to 2.
         //Afterward sink is called, which might decrement the reference count again by 1 if the instance
         //is not yet sunk. See: https://docs.gtk.org/gobject/method.Closure.sink.html
@@ -22,7 +22,7 @@ public partial class Closure
             .NewObject((uint) Marshal.SizeOf<Internal.ClosureData>(), handle.DangerousGetHandle())
             .OwnedCopy();
 
-        Debug.WriteLine($"Instantiating Closure: Address {Handle.DangerousGetHandle()}.");
+        Debug.WriteLine($"Handle {handle.DangerousGetHandle()}: Instantiating Closure {Handle.DangerousGetHandle()}.");
 
         _closureMarshal = InternalCallback; //Save delegate to keep instance alive
 
@@ -51,10 +51,5 @@ public partial class Closure
         {
             GLib.UnhandledException.Raise(e);
         }
-    }
-
-    partial void OnDispose()
-    {
-        Debug.WriteLine($"Disposing Closure: Address {Handle.DangerousGetHandle()}.");
     }
 }


### PR DESCRIPTION
The "OnDispose" method was only called if a user explicitly called "Dispose()". If an object got collected via the GC the "OnDispose" method was not called, which is probably not what a user would expect.

Therefore, the "OnDispose" method got replaced by an "OnReleaseHandle" method for typed records which gets always called if a typed record gets freed.

This affects the debug message of a closure which indicates the collection of a closure if GirCore is compiled in debug mode.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
