### PR TITLE
Add fixer for record-field name collision

### DIFF
--- a/src/Generation/Generator/Fixer/Record/PropertyNamedLikeRecordFixer.cs
+++ b/src/Generation/Generator/Fixer/Record/PropertyNamedLikeRecordFixer.cs
@@ -1,0 +1,20 @@
+using Generator.Model;
+
+namespace Generator.Fixer.Record;
+
+internal class PropertyNamedLikeRecordFixer : Fixer<GirModel.Record>
+{
+    public void Fixup(GirModel.Record record)
+    {
+        foreach (var field in record.Fields)
+        {
+            var name = Field.GetName(field);
+            if (name == record.Name)
+            {
+                Field.SetName(field, $"{name}_");
+                Log.Information($"Field {field.Name} is named like its containing record {record.Namespace.Name}.{record.Name}. This is not allowed. The field should be created with a suffix and be rewritten to its original name");
+                return;
+            }
+        }
+    }
+}

--- a/src/Generation/Generator/Fixer/Records.cs
+++ b/src/Generation/Generator/Fixer/Records.cs
@@ -8,6 +8,7 @@ public static class Records
     private static readonly List<Fixer<GirModel.Record>> Fixers =
     [
         new DisableBrokenTypes(),
+        new PropertyNamedLikeRecordFixer(),
         new InternalMethodsNamedLikeRecordFixer(),
         new MethodWithInOutInstanceParameterFixer(),
         new PublicMethodsColldingWithFieldFixer(),

--- a/src/Generation/Generator/Model/Field.cs
+++ b/src/Generation/Generator/Model/Field.cs
@@ -1,9 +1,24 @@
+using System.Collections.Generic;
+
 namespace Generator.Model;
 
 internal static class Field
 {
+    private static readonly Dictionary<GirModel.Field, string> FixedNames = new();
+
     public static string GetName(GirModel.Field field)
     {
+        if (FixedNames.TryGetValue(field, out var value))
+            return value;
+
         return field.Name.ToPascalCase();
+    }
+
+    public static void SetName(GirModel.Field field, string name)
+    {
+        lock (FixedNames)
+        {
+            FixedNames[field] = name;
+        }
     }
 }


### PR DESCRIPTION
e.g. Length.Length using PropertyNamedLikeRecordFixer

- [X] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
