### PR TITLE
Add missing support for ulong in GObject.Value to fix property accessors

### DIFF
--- a/src/Libs/GObject-2.0/Public/Value.cs
+++ b/src/Libs/GObject-2.0/Public/Value.cs
@@ -22,6 +22,7 @@ public partial class Value : IDisposable
     public Value(int value) : this(Type.Int) => SetInt(value);
     public Value(uint value) : this(Type.UInt) => SetUint(value);
     public Value(long value) : this(Type.Long) => SetLong(value);
+    public Value(ulong value) : this(Type.UInt64) => SetUint64(value);
     public Value(double value) : this(Type.Double) => SetDouble(value);
     public Value(float value) : this(Type.Float) => SetFloat(value);
     public Value(string value) : this(Type.String) => SetString(value);
@@ -59,6 +60,7 @@ public partial class Value : IDisposable
             (nuint) BasicType.UInt => GetUint(),
             (nuint) BasicType.Int => GetInt(),
             (nuint) BasicType.Long => GetLong(),
+            (nuint) BasicType.UInt64 => GetUint64(),
             (nuint) BasicType.Double => GetDouble(),
             (nuint) BasicType.Float => GetFloat(),
             (nuint) BasicType.String => GetString(),
@@ -174,6 +176,9 @@ public partial class Value : IDisposable
                 break;
             case long l:
                 SetLong(l);
+                break;
+            case ulong l:
+                SetUint64(l);
                 break;
             case float f:
                 SetFloat(f);

--- a/src/Native/GirTestLib/girtest-property-tester.c
+++ b/src/Native/GirTestLib/girtest-property-tester.c
@@ -19,6 +19,7 @@ typedef enum
     PROP_OBJECT_VALUE = 6,
     PROP_EXECUTOR_VALUE = 7,
     PROP_EXECUTOR_ANONYMOUS_VALUE = 8,
+    PROP_UINT64_VALUE = 9,
     N_PROPERTIES
 } PropertyTesterProperty;
 
@@ -34,6 +35,7 @@ struct _GirTestPropertyTester
     GirTestExecutor* executor_anonymous_value;
     gint int_value;
     gboolean boolean_value;
+    guint64 uint64_value;
 
 };
 
@@ -76,6 +78,9 @@ girtest_property_tester_get_property (GObject    *object,
     case PROP_EXECUTOR_ANONYMOUS_VALUE:
         g_value_set_object (value, self->executor_anonymous_value);
         break;
+    case PROP_UINT64_VALUE:
+        g_value_set_uint64 (value, self->uint64_value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -108,6 +113,9 @@ girtest_property_tester_set_property (GObject      *object,
         break;
     case PROP_OBJECT_VALUE:
         self->object_value = g_value_get_object (value);
+        break;
+    case PROP_UINT64_VALUE:
+        self->uint64_value = g_value_get_uint64 (value);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -186,6 +194,15 @@ girtest_property_tester_class_init(GirTestPropertyTesterClass *class)
                                    "A boolean value",
                                    FALSE  /* default value */,
                                    G_PARAM_READWRITE);
+
+    properties[PROP_UINT64_VALUE] =
+          g_param_spec_uint64 ("uint64-value",
+                               "UInt64 Value",
+                               "A uint64 value",
+                               0,
+                               G_MAXUINT64,
+                               0  /* default value */,
+                               G_PARAM_READWRITE);
 
     g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 }

--- a/src/Tests/Libs/GirTest-0.1.Tests/PropertyTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/PropertyTest.cs
@@ -100,6 +100,18 @@ public class PropertyTest : Test
         obj.BooleanValue.Should().Be(b);
     }
 
+    [DataTestMethod]
+    [DataRow(42ul)]
+    [DataRow(ulong.MinValue)]
+    [DataRow(ulong.MaxValue)]
+    public void TestUInt64Property(ulong val)
+    {
+        var obj = PropertyTester.New();
+        obj.Uint64Value = val;
+
+        obj.Uint64Value.Should().Be(val);
+    }
+
     [TestMethod]
     public void TestObjectProperty()
     {


### PR DESCRIPTION
As bug #1258 notes, we also should set up tests for `long` values as well

Bug: #1257

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
