### PR TITLE
Properly support Long / ULong / Int64 / UInt64 properties

### DIFF
--- a/src/Libs/GObject-2.0/Public/Value.cs
+++ b/src/Libs/GObject-2.0/Public/Value.cs
@@ -21,7 +21,7 @@ public partial class Value : IDisposable
     public Value(bool value) : this(Type.Boolean) => SetBoolean(value);
     public Value(int value) : this(Type.Int) => SetInt(value);
     public Value(uint value) : this(Type.UInt) => SetUint(value);
-    public Value(long value) : this(Type.Long) => SetLong(value);
+    public Value(long value) : this(Type.Int64) => SetInt64(value);
     public Value(ulong value) : this(Type.UInt64) => SetUint64(value);
     public Value(double value) : this(Type.Double) => SetDouble(value);
     public Value(float value) : this(Type.Float) => SetFloat(value);
@@ -49,7 +49,7 @@ public partial class Value : IDisposable
     /// </summary>
     /// <returns>The content of this wrapped in an object</returns>
     /// <exception cref="NotSupportedException">
-    /// The value cannot be casted to the given type.
+    /// The value cannot be cast to the given type.
     /// </exception>
     internal object? Extract()
     {
@@ -59,8 +59,10 @@ public partial class Value : IDisposable
             (nuint) BasicType.Boolean => GetBoolean(),
             (nuint) BasicType.UInt => GetUint(),
             (nuint) BasicType.Int => GetInt(),
+            (nuint) BasicType.ULong => GetUlong(),
             (nuint) BasicType.Long => GetLong(),
             (nuint) BasicType.UInt64 => GetUint64(),
+            (nuint) BasicType.Int64 => GetInt64(),
             (nuint) BasicType.Double => GetDouble(),
             (nuint) BasicType.Float => GetFloat(),
             (nuint) BasicType.String => GetString(),
@@ -175,10 +177,10 @@ public partial class Value : IDisposable
                     SetEnum(e);
                 break;
             case long l:
-                SetLong(l);
+                SetLongDependingOnType(l);
                 break;
             case ulong l:
-                SetUint64(l);
+                SetUlongDependingOnType(l);
                 break;
             case float f:
                 SetFloat(f);
@@ -203,6 +205,38 @@ public partial class Value : IDisposable
                 break;
             default:
                 throw new NotSupportedException($"Type {value.GetType()} is not supported as a value type");
+        }
+    }
+
+    private void SetLongDependingOnType(long value)
+    {
+        var type = GetTypeValue();
+        switch (type)
+        {
+            case (nuint) BasicType.Long:
+                SetLong(value);
+                return;
+            case (nuint) BasicType.Int64:
+                SetInt64(value);
+                return;
+            default:
+                throw new Exception($"Type {type} is not a supported long type");
+        }
+    }
+
+    private void SetUlongDependingOnType(ulong value)
+    {
+        var type = GetTypeValue();
+        switch (type)
+        {
+            case (nuint) BasicType.ULong:
+                SetUlong(value);
+                return;
+            case (nuint) BasicType.UInt64:
+                SetUint64(value);
+                return;
+            default:
+                throw new Exception($"Type {type} is not a supported long type");
         }
     }
 }

--- a/src/Native/GirTestLib/girtest-property-tester.c
+++ b/src/Native/GirTestLib/girtest-property-tester.c
@@ -20,6 +20,9 @@ typedef enum
     PROP_EXECUTOR_VALUE = 7,
     PROP_EXECUTOR_ANONYMOUS_VALUE = 8,
     PROP_UINT64_VALUE = 9,
+    PROP_INT64_VALUE = 10,
+    PROP_LONG_VALUE = 11,
+    PROP_ULONG_VALUE = 12,
     N_PROPERTIES
 } PropertyTesterProperty;
 
@@ -36,7 +39,9 @@ struct _GirTestPropertyTester
     gint int_value;
     gboolean boolean_value;
     guint64 uint64_value;
-
+    gint64 int64_value;
+    glong long_value;
+    gulong ulong_value;
 };
 
 G_DEFINE_TYPE(GirTestPropertyTester, girtest_property_tester, G_TYPE_OBJECT)
@@ -81,6 +86,15 @@ girtest_property_tester_get_property (GObject    *object,
     case PROP_UINT64_VALUE:
         g_value_set_uint64 (value, self->uint64_value);
         break;
+    case PROP_INT64_VALUE:
+        g_value_set_int64 (value, self->int64_value);
+        break;
+    case PROP_LONG_VALUE:
+        g_value_set_long (value, self->long_value);
+        break;
+    case PROP_ULONG_VALUE:
+        g_value_set_ulong (value, self->ulong_value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -116,6 +130,15 @@ girtest_property_tester_set_property (GObject      *object,
         break;
     case PROP_UINT64_VALUE:
         self->uint64_value = g_value_get_uint64 (value);
+        break;
+    case PROP_INT64_VALUE:
+        self->int64_value = g_value_get_int64 (value);
+        break;
+    case PROP_LONG_VALUE:
+        self->long_value = g_value_get_long (value);
+        break;
+    case PROP_ULONG_VALUE:
+        self->ulong_value = g_value_get_ulong (value);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -203,6 +226,33 @@ girtest_property_tester_class_init(GirTestPropertyTesterClass *class)
                                G_MAXUINT64,
                                0  /* default value */,
                                G_PARAM_READWRITE);
+
+    properties[PROP_INT64_VALUE] =
+            g_param_spec_int64 ("int64-value",
+                                "Int64 Value",
+                                "An int64 value",
+                                G_MININT64,
+                                G_MAXINT64,
+                                0  /* default value */,
+                                G_PARAM_READWRITE);
+
+    properties[PROP_LONG_VALUE] =
+          g_param_spec_long ("long-value",
+                             "Long Value",
+                             "A glong value",
+                             G_MINLONG,
+                             G_MAXLONG,
+                             0  /* default value */,
+                             G_PARAM_READWRITE);
+
+    properties[PROP_ULONG_VALUE] =
+          g_param_spec_ulong ("ulong-value",
+                              "ULong Value",
+                              "A gulong value",
+                              0,
+                              G_MAXULONG,
+                              0  /* default value */,
+                              G_PARAM_READWRITE);
 
     g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 }

--- a/src/Tests/Libs/GObject-2.0.Tests/Records/ValueTest.cs
+++ b/src/Tests/Libs/GObject-2.0.Tests/Records/ValueTest.cs
@@ -70,9 +70,10 @@ public class ValueTest : Test
     public void SupportsLong(long value)
     {
         var v = new Value(value);
-        v.GetLong().Should().Be(value);
+        v.GetInt64().Should().Be(value);
 
-        EnsureBasicType(v, BasicType.Long);
+        //BasicType.Int64 because Int64 is 64bit wide on all systems (which long is not)
+        EnsureBasicType(v, BasicType.Int64);
     }
 
     [DataTestMethod]

--- a/src/Tests/Libs/GirTest-0.1.Tests/PropertyTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/PropertyTest.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -110,6 +109,76 @@ public class PropertyTest : Test
         obj.Uint64Value = val;
 
         obj.Uint64Value.Should().Be(val);
+        obj.Uint64Value.Should().BeOfType(typeof(ulong));
+    }
+
+    [DataTestMethod]
+    [DataRow(42)]
+    [DataRow(long.MinValue)]
+    [DataRow(long.MaxValue)]
+    public void TestInt64Property(long val)
+    {
+        var obj = PropertyTester.New();
+        obj.Int64Value = val;
+
+        obj.Int64Value.Should().Be(val);
+        obj.Int64Value.Should().BeOfType(typeof(long));
+    }
+
+    [DataTestMethod]
+    [DataRow(42)]
+    [DataRow(long.MinValue)]
+    [DataRow(long.MaxValue)]
+    [PlatformCondition(Platform.Unix64)]
+    public void TestLongProperty64BitWideSystems(long val)
+    {
+        var obj = PropertyTester.New();
+        obj.LongValue = val;
+
+        obj.LongValue.Should().Be(val);
+        obj.LongValue.Should().BeOfType(typeof(long));
+    }
+
+    [DataTestMethod]
+    [DataRow(42)]
+    [DataRow(int.MinValue)]
+    [DataRow(int.MaxValue)]
+    [PlatformCondition(Platform.Windows | Platform.Unix32)]
+    public void TestLongProperty32BitWideSystems(int val)
+    {
+        var obj = PropertyTester.New();
+        obj.LongValue = val;
+
+        obj.LongValue.Should().Be(val);
+        obj.LongValue.Should().BeOfType(typeof(long));
+    }
+
+    [DataTestMethod]
+    [DataRow(42ul)]
+    [DataRow(ulong.MinValue)]
+    [DataRow(ulong.MaxValue)]
+    [PlatformCondition(Platform.Unix64)]
+    public void TestULongProperty64BitWideSystems(ulong val)
+    {
+        var obj = PropertyTester.New();
+        obj.UlongValue = val;
+
+        obj.UlongValue.Should().Be(val);
+        obj.UlongValue.Should().BeOfType(typeof(ulong));
+    }
+
+    [DataTestMethod]
+    [DataRow(42u)]
+    [DataRow(uint.MinValue)]
+    [DataRow(uint.MaxValue)]
+    [PlatformCondition(Platform.Windows | Platform.Unix32)]
+    public void TestULongProperty32BitWideSystems(uint val)
+    {
+        var obj = PropertyTester.New();
+        obj.UlongValue = val;
+
+        obj.UlongValue.Should().Be(val);
+        obj.UlongValue.Should().BeOfType(typeof(ulong));
     }
 
     [TestMethod]


### PR DESCRIPTION
- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

Fixes #1258 

Please note: Creating a custom `GObject.Value(long)` is now setting the type to `Int64` instead of `long`.
