### PR TITLE
Add GObject.Object to generic type constraint of instance factory/wrapper

### DIFF
--- a/src/Libs/GObject-2.0/Internal/DynamicInstanceFactory.cs
+++ b/src/Libs/GObject-2.0/Internal/DynamicInstanceFactory.cs
@@ -13,7 +13,7 @@ public static class DynamicInstanceFactory
         InstanceFactories.Add(type, handleWrapper);
     }
 
-    internal static object Create<TFallback>(IntPtr handle, bool ownsHandle) where TFallback : InstanceFactory, GTypeProvider
+    internal static object Create<TFallback>(IntPtr handle, bool ownsHandle) where TFallback : GObject.Object, InstanceFactory, GTypeProvider
     {
         var type = GetType(handle);
         var createInstance = GetInstanceFactory<TFallback>(type);

--- a/src/Libs/GObject-2.0/Internal/InstanceWrapper.cs
+++ b/src/Libs/GObject-2.0/Internal/InstanceWrapper.cs
@@ -4,14 +4,14 @@ namespace GObject.Internal;
 
 public static class InstanceWrapper
 {
-    public static object? WrapNullableHandle<TFallback>(IntPtr handle, bool ownedRef) where TFallback : InstanceFactory, GTypeProvider
+    public static object? WrapNullableHandle<TFallback>(IntPtr handle, bool ownedRef) where TFallback : GObject.Object, InstanceFactory, GTypeProvider
     {
         return handle == IntPtr.Zero
             ? null
             : WrapHandle<TFallback>(handle, ownedRef);
     }
 
-    public static object WrapHandle<TFallback>(IntPtr handle, bool ownedRef) where TFallback : InstanceFactory, GTypeProvider
+    public static object WrapHandle<TFallback>(IntPtr handle, bool ownedRef) where TFallback : GObject.Object, InstanceFactory, GTypeProvider
     {
         if (handle == IntPtr.Zero)
             throw new NullReferenceException("Failed to wrap handle: Null handle passed to WrapHandle.");


### PR DESCRIPTION
Prevents accidental use of DynamicInstanceFactory and InstanceWrapper for types that are not objects/classes, such as records. Records should use BoxedWrapper instead to wrap handles.

Closes #1315 

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
