### PR TITLE
GLib.SList: Add IEnumerable<SListElement> and related extensions

### DIFF
--- a/src/Libs/GLib-2.0/Public/SList.Enumerator.cs
+++ b/src/Libs/GLib-2.0/Public/SList.Enumerator.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace GLib;
+
+public partial class SList
+{
+    public unsafe struct Enumerator : IEnumerator<SListElement>
+    {
+        private SList SList { get; }
+        private Internal.SListData* CurrentSList { get; set; }
+
+        public Enumerator(SList slist)
+        {
+            SList = slist;
+            Reset();
+        }
+
+        public SListElement Current { get; private set; }
+        object IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            if ((IntPtr) CurrentSList == IntPtr.Zero)
+                return false;
+
+            Current = new SListElement
+            {
+                Data = CurrentSList->Data
+            };
+
+            CurrentSList = (Internal.SListData*) CurrentSList->Next;
+            return true;
+        }
+
+        public void Reset()
+        {
+            CurrentSList = (Internal.SListData*) SList.Handle.DangerousGetHandle();
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/src/Libs/GLib-2.0/Public/SList.cs
+++ b/src/Libs/GLib-2.0/Public/SList.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace GLib;
+
+public partial class SList : IEnumerable<SListElement>
+{
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return new Enumerator(this);
+    }
+
+    IEnumerator<SListElement> IEnumerable<SListElement>.GetEnumerator()
+    {
+        return new Enumerator(this);
+    }
+
+    public Enumerator GetEnumerator()
+    {
+        return new Enumerator(this);
+    }
+}

--- a/src/Libs/GLib-2.0/Public/SListElement.cs
+++ b/src/Libs/GLib-2.0/Public/SListElement.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GLib;
+
+public struct SListElement
+{
+    public IntPtr Data;
+
+    /// <summary>
+    /// Create managed string from UTF-8 data
+    /// </summary>
+    /// <returns>String from UTF-8 data of pointer</returns>
+    public readonly string? ToStringUTF8()
+    {
+        return Marshal.PtrToStringUTF8(Data);
+    }
+}

--- a/src/Libs/GLib-2.0/Public/SListExtensions.cs
+++ b/src/Libs/GLib-2.0/Public/SListExtensions.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace GLib;
+
+public static class SListExtensions
+{
+    public static IEnumerable<string?> AsStringsUTF8(this IEnumerable<SListElement> source)
+    {
+        foreach (var item in source)
+        {
+            yield return item.ToStringUTF8();
+        }
+    }
+}

--- a/src/Libs/GObject-2.0/Internal/DynamicInstanceFactory.cs
+++ b/src/Libs/GObject-2.0/Internal/DynamicInstanceFactory.cs
@@ -13,7 +13,7 @@ public static class DynamicInstanceFactory
         InstanceFactories.Add(type, handleWrapper);
     }
 
-    internal static object Create<TFallback>(IntPtr handle, bool ownsHandle) where TFallback : InstanceFactory, GTypeProvider
+    internal static object Create<TFallback>(IntPtr handle, bool ownsHandle) where TFallback : GObject.Object, InstanceFactory, GTypeProvider
     {
         var type = GetType(handle);
         var createInstance = GetInstanceFactory<TFallback>(type);

--- a/src/Libs/GObject-2.0/Internal/InstanceWrapper.cs
+++ b/src/Libs/GObject-2.0/Internal/InstanceWrapper.cs
@@ -4,14 +4,14 @@ namespace GObject.Internal;
 
 public static class InstanceWrapper
 {
-    public static object? WrapNullableHandle<TFallback>(IntPtr handle, bool ownedRef) where TFallback : InstanceFactory, GTypeProvider
+    public static object? WrapNullableHandle<TFallback>(IntPtr handle, bool ownedRef) where TFallback : GObject.Object, InstanceFactory, GTypeProvider
     {
         return handle == IntPtr.Zero
             ? null
             : WrapHandle<TFallback>(handle, ownedRef);
     }
 
-    public static object WrapHandle<TFallback>(IntPtr handle, bool ownedRef) where TFallback : InstanceFactory, GTypeProvider
+    public static object WrapHandle<TFallback>(IntPtr handle, bool ownedRef) where TFallback : GObject.Object, InstanceFactory, GTypeProvider
     {
         if (handle == IntPtr.Zero)
             throw new NullReferenceException("Failed to wrap handle: Null handle passed to WrapHandle.");

--- a/src/Libs/GObject-2.0/Public/SListExtensions.cs
+++ b/src/Libs/GObject-2.0/Public/SListExtensions.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace GObject;
+
+public static class SListExtensions
+{
+    public static T ToObject<T>(this GLib.SListElement element) where T : Object, InstanceFactory, GTypeProvider
+    {
+        return (T) Internal.InstanceWrapper.WrapHandle<T>(element.Data, false);
+    }
+
+    public static T ToBoxed<T>(this GLib.SListElement element) where T : GLib.BoxedRecord, GTypeProvider
+    {
+        return (T) Internal.BoxedWrapper.WrapHandle(element.Data, false, T.GetGType());
+    }
+
+    public static IEnumerable<T> AsObjects<T>(this IEnumerable<GLib.SListElement> source) where T : Object, InstanceFactory, GTypeProvider
+    {
+        foreach (var item in source)
+        {
+            yield return item.ToObject<T>();
+        }
+    }
+
+    public static IEnumerable<T> AsBoxed<T>(this IEnumerable<GLib.SListElement> source) where T : GLib.BoxedRecord, GTypeProvider
+    {
+        foreach (var item in source)
+        {
+            yield return item.ToBoxed<T>();
+        }
+    }
+}

--- a/src/Tests/Libs/GLib-2.0.Tests/Classes/SListTest.cs
+++ b/src/Tests/Libs/GLib-2.0.Tests/Classes/SListTest.cs
@@ -1,0 +1,61 @@
+using System;
+using AwesomeAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GLib.Tests;
+
+[TestClass, TestCategory("UnitTest")]
+public class SListTest : Test
+{
+    [TestMethod]
+    public void CanEnumerateSList()
+    {
+        var valueArr = new IntPtr[] { 1234, -1234, 0 };
+
+        // Create zeroed SList handle to pass to "Append"
+        var slist = new SList(new Internal.SListOwnedHandle(IntPtr.Zero));
+        foreach (var value in valueArr)
+        {
+            // First append creates a new SList
+            slist = SList.Append(slist, value);
+        }
+
+        // Length should be 3 after creating a new SList by using "Append" three times
+        SList.Length(slist).Should().Be((uint) valueArr.Length);
+
+        var index = 0;
+        foreach (SListElement element in slist)
+        {
+            // Validate pointer values
+            element.Data.Should().Be(valueArr[index]);
+            index++;
+        }
+    }
+
+    [TestMethod]
+    public void CanEnumerateSListString()
+    {
+        // Test enumerable for GLib.SList with strings stored as a pointer
+        var valueArr = new Internal.NullableUtf8StringHandle[]
+        {
+            Internal.NullableUtf8StringOwnedHandle.Create("Hello World"),
+            Internal.NullableUtf8StringOwnedHandle.Create(""),
+            Internal.NullableUtf8StringOwnedHandle.Create(null)
+        };
+
+        var slist = new SList(new Internal.SListOwnedHandle(IntPtr.Zero));
+        foreach (var value in valueArr)
+        {
+            slist = SList.Append(slist, value.DangerousGetHandle());
+        }
+
+        SList.Length(slist).Should().Be((uint) valueArr.Length);
+
+        int index = 0;
+        foreach (var value in slist.AsStringsUTF8())
+        {
+            value.Should().Be(valueArr[index].ConvertToString());
+            index++;
+        }
+    }
+}

--- a/src/Tests/Libs/GLib-2.0.Tests/Classes/SListTest.cs
+++ b/src/Tests/Libs/GLib-2.0.Tests/Classes/SListTest.cs
@@ -13,6 +13,7 @@ public class SListTest : Test
         var valueArr = new IntPtr[] { 1234, -1234, 0 };
 
         // Create zeroed SList handle to pass to "Append"
+        // TODO: Change to "new SList(null)" once https://github.com/gircore/gir.core/issues/1318 is merged
         var slist = new SList(new Internal.SListOwnedHandle(IntPtr.Zero));
         foreach (var value in valueArr)
         {
@@ -43,6 +44,8 @@ public class SListTest : Test
             Internal.NullableUtf8StringOwnedHandle.Create(null)
         };
 
+        // Create zeroed SList handle to pass to "Append"
+        // TODO: Change to "new SList(null)" once https://github.com/gircore/gir.core/issues/1318 is merged
         var slist = new SList(new Internal.SListOwnedHandle(IntPtr.Zero));
         foreach (var value in valueArr)
         {

--- a/src/Tests/Libs/GObject-2.0.Tests/Extensions/SListTest.cs
+++ b/src/Tests/Libs/GObject-2.0.Tests/Extensions/SListTest.cs
@@ -19,6 +19,8 @@ public class SListTest : Test
             new BindingGroup()
         };
 
+        // Create zeroed SList handle to pass to "Append"
+        // TODO: Change to "new SList(null)" once https://github.com/gircore/gir.core/issues/1318 is merged
         var index = 0;
         var slist = new SList(new GLib.Internal.SListOwnedHandle(IntPtr.Zero));
         foreach (var value in valueArr)
@@ -49,6 +51,8 @@ public class SListTest : Test
             new Value("Hello World"),
         };
 
+        // Create zeroed SList handle to pass to "Append"
+        // TODO: Change to "new SList(null)" once https://github.com/gircore/gir.core/issues/1318 is merged
         var index = 0;
         var slist = new SList(new GLib.Internal.SListOwnedHandle(IntPtr.Zero));
         foreach (var value in valueArr)

--- a/src/Tests/Libs/GObject-2.0.Tests/Extensions/SListTest.cs
+++ b/src/Tests/Libs/GObject-2.0.Tests/Extensions/SListTest.cs
@@ -1,0 +1,69 @@
+using System;
+using AwesomeAssertions;
+using GLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GObject.Tests;
+
+[TestClass, TestCategory("UnitTest")]
+public class SListTest : Test
+{
+    [TestMethod]
+    public void CanEnumerateSListObjects()
+    {
+        // Test enumerable for GLib.SList with GObject.Object stored as a pointer
+        var valueArr = new[]
+        {
+            new BindingGroup(),
+            new BindingGroup(),
+            new BindingGroup()
+        };
+
+        var index = 0;
+        var slist = new SList(new GLib.Internal.SListOwnedHandle(IntPtr.Zero));
+        foreach (var value in valueArr)
+        {
+            slist = SList.Append(slist, value.Handle.DangerousGetHandle());
+            index++;
+        }
+
+        SList.Length(slist).Should().Be((uint) valueArr.Length);
+
+        index = 0;
+        foreach (var value in slist.AsObjects<BindingGroup>())
+        {
+            var origHandle = valueArr[index].Handle.DangerousGetHandle();
+            value.Handle.DangerousGetHandle().Should().Be(origHandle);
+            index++;
+        }
+    }
+
+    [TestMethod]
+    public void CanEnumerateSListBoxedRecords()
+    {
+        // Test enumerable for GLib.SList with GObject.Object stored as a pointer
+        var valueArr = new[]
+        {
+            new Value(1234),
+            new Value(46.19531),
+            new Value("Hello World"),
+        };
+
+        var index = 0;
+        var slist = new SList(new GLib.Internal.SListOwnedHandle(IntPtr.Zero));
+        foreach (var value in valueArr)
+        {
+            slist = SList.Append(slist, value.Handle.DangerousGetHandle());
+            index++;
+        }
+
+        SList.Length(slist).Should().Be((uint) valueArr.Length);
+
+        index = 0;
+        foreach (var value in slist.AsBoxed<Value>())
+        {
+            value.Extract().Should().Be(valueArr[index].Extract());
+            index++;
+        }
+    }
+}


### PR DESCRIPTION
GLib.SList: Add enumerator and extension methods for element conversion
SList.Enumerator allows enumerating the list data with `IEnumerable<SListElement>` and with foreach loops.
The extension methods on `IEnumerable<SListElement>` allow conversion to object/boxed record instances or strings.

Includes unit tests.

* `ToBoxed` and `ToObject` are extension methods as part of GObject. They need access to the type system for wrapping the right handles.
* `ToStringUTF8` is used for UTF-8 string pointer data.
* Use `AsBoxed`, `AsObjects` and `AsStringsUTF8` for enumeration on a foreach loop.

Part of #588 

- [X] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
