### PR TITLE
Add Pango unit conversion/rounding functions from C function macros

### DIFF
--- a/src/Libs/Pango-1.0/Public/Functions.cs
+++ b/src/Libs/Pango-1.0/Public/Functions.cs
@@ -1,0 +1,74 @@
+﻿namespace Pango;
+
+public partial class Functions
+{
+    /// <summary>
+    /// Converts a dimension to Pango units by multiplying by the Pango scale.
+    /// </summary>
+    /// <param name="pixels">A dimension in device units</param>
+    /// <returns>Dimension in Pango units</returns>
+    public static int FromPixels(int pixels)
+    {
+        return pixels * Constants.SCALE;
+    }
+
+    /// <summary>
+    /// Converts a dimension to device units by rounding.
+    /// </summary>
+    /// <param name="units">A dimension in Pango units</param>
+    /// <returns>Rounded dimension in device units</returns>
+    public static int ToPixels(int units)
+    {
+        return (units + Constants.SCALE / 2) >> 10;
+    }
+
+    /// <summary>
+    /// Converts a dimension to device units by flooring.
+    /// </summary>
+    /// <param name="units">A dimension in Pango units</param>
+    /// <returns>Floored dimension in device units</returns>
+    public static int ToPixelsFloor(int units)
+    {
+        return units >> 10;
+    }
+
+    /// <summary>
+    /// Converts a dimension to device units by ceiling.
+    /// </summary>
+    /// <param name="units">A dimension in Pango units</param>
+    /// <returns>Ceiled dimension in device units</returns>
+    public static int ToPixelsCeil(int units)
+    {
+        return units & ~(Constants.SCALE - 1);
+    }
+
+    /// <summary>
+    /// Rounds a dimension down to whole device units, but does not convert it to device units.
+    /// </summary>
+    /// <param name="units">A dimension in Pango units</param>
+    /// <returns>Rounded down dimension in device units</returns>
+    public static int UnitsFloor(int units)
+    {
+        return (units + Constants.SCALE - 1) >> 10;
+    }
+
+    /// <summary>
+    /// Rounds a dimension up to whole device units, but does not convert it to device units.
+    /// </summary>
+    /// <param name="units">A dimension in Pango units</param>
+    /// <returns>Rounded up dimension in device units</returns>
+    public static int UnitsCeil(int units)
+    {
+        return (units + (Constants.SCALE - 1)) & ~(Constants.SCALE - 1);
+    }
+
+    /// <summary>
+    /// Rounds a dimension to whole device units, but does not convert it to device units.
+    /// </summary>
+    /// <param name="units">A dimension in Pango units</param>
+    /// <returns>Rounded dimension in device units</returns>
+    public static int UnitsRound(int units)
+    {
+        return (units + (Constants.SCALE >> 1)) & ~(Constants.SCALE - 1);
+    }
+}


### PR DESCRIPTION
See #1319

I put the functions into `Functions.cs` as there are already similar unit conversion functions available as real functions in `Functions.Generated.cs`, so they match and can be found in the same place.

| C function macro | C# name | Notes |
|--------|--------|--------|
| - | Pango.Functions.FromPixels | Not in Pango, was a helper in previous wrappers |
| PIXELS | Pango.Functions.ToPixels | See code comments |
| PIXELS_CEIL | Pango.Functions.ToPixelsCeil | See code comments |
| PIXELS_FLOOR | Pango.Functions.ToPixelsFloor | See code comments |
| UNITS_FLOOR | Pango.Functions.UnitsFloor | See code comments |
| UNITS_CEIL | Pango.Functions.UnitsCeil | See code comments |
| UNITS_ROUND | Pango.Functions.UnitsRound | See code comments |

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
