### PR TITLE
Add Pango CSS scale factor constants

### DIFF
--- a/src/Libs/Pango-1.0/Public/Constants.cs
+++ b/src/Libs/Pango-1.0/Public/Constants.cs
@@ -1,0 +1,39 @@
+﻿namespace Pango;
+
+public partial class Constants
+{
+    /// <summary>
+    /// The CSS scale factor for three shrinking steps (1 / (1.2 * 1.2 * 1.2)).
+    /// </summary>
+    public const double XX_SMALL = 0.5787037037037;
+
+    /// <summary>
+    /// The scale factor for two shrinking steps (1 / (1.2 * 1.2)).
+    /// </summary>
+    public const double X_SMALL = 0.6944444444444;
+
+    /// <summary>
+    /// The scale factor for one shrinking step (1 / 1.2).
+    /// </summary>
+    public const double SMALL = 0.8333333333333;
+
+    /// <summary>
+    /// The scale factor for normal size (1.0).
+    /// </summary>
+    public const double MEDIUM = 1.0;
+
+    /// <summary>
+    /// The scale factor for one magnification step (1.2).
+    /// </summary>
+    public const double LARGE = 1.2;
+
+    /// <summary>
+    /// The scale factor for two magnification steps (1.2 * 1.2).
+    /// </summary>
+    public const double X_LARGE = 1.44;
+
+    /// <summary>
+    /// The scale factor for three magnification steps (1.2 * 1.2 * 1.2).
+    /// </summary>
+    public const double XX_LARGE = 1.728;
+}


### PR DESCRIPTION
See header https://gitlab.gnome.org/GNOME/pango/-/blob/main/pango/pango-font.h#L261

* Pango.Constants.XX_SMALL
* Pango.Constants.X_SMALL
* Pango.Constants.SMALL
* Pango.Constants.MEDIUM
* Pango.Constants.LARGE
* Pango.Constants.X_LARGE
* Pango.Constants.XX_LARGE

Other wrappers like GtkSharp or Vala have also introduced these as custom code.
e.g. https://gitlab.gnome.org/GNOME/vala/-/blob/main/vapi/metadata/Pango-1.0-custom.vala

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
