### PR TITLE
Fix typo in exception for TypedRecord ParameterConverter

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/Parameter/Converter/TypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Internal/Parameter/Converter/TypedRecord.cs
@@ -36,6 +36,6 @@ internal class TypedRecord : ParameterConverter
     {
         { Direction: GirModel.Direction.In } => ParameterDirection.In(),
         { Direction: GirModel.Direction.InOut } => ParameterDirection.In(),
-        _ => throw new Exception($"Unknown parameter direction for opaque typed record parameter {parameter.Name}")
+        _ => throw new Exception($"Unknown parameter direction for typed record parameter {parameter.Name}")
     };
 }


### PR DESCRIPTION
Opaque typed record -> typed record

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
