### PR TITLE
Generate methods with typed records as out parameter (non-nullable, no transfer)

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/Parameter/Converter/TypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Internal/Parameter/Converter/TypedRecord.cs
@@ -28,6 +28,7 @@ internal class TypedRecord : ParameterConverter
         {
             { Direction: GirModel.Direction.In, Transfer: GirModel.Transfer.None } => Model.TypedRecord.GetFullyQuallifiedHandle(type),
             { Direction: GirModel.Direction.In, Transfer: GirModel.Transfer.Full } => Model.TypedRecord.GetFullyQuallifiedUnownedHandle(type),
+            { Direction: GirModel.Direction.Out, Transfer: GirModel.Transfer.None } => Model.TypedRecord.GetFullyQuallifiedHandle(type),
             _ => throw new Exception($"Can't detect record parameter type {parameter.Name}: CallerAllocates={parameter.CallerAllocates} Direction={parameter.Direction} Transfer={parameter.Transfer}")
         };
     }
@@ -36,6 +37,7 @@ internal class TypedRecord : ParameterConverter
     {
         { Direction: GirModel.Direction.In } => ParameterDirection.In(),
         { Direction: GirModel.Direction.InOut } => ParameterDirection.In(),
+        { Direction: GirModel.Direction.Out, CallerAllocates: true } => ParameterDirection.In(), //We can use "in" here because caller allocates the memory
         _ => throw new Exception($"Unknown parameter direction for typed record parameter {parameter.Name}")
     };
 }

--- a/src/Generation/Generator/Renderer/Public/Parameter/Converter/TypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Public/Parameter/Converter/TypedRecord.cs
@@ -27,6 +27,6 @@ internal class TypedRecord : ParameterConverter
     {
         { Direction: GirModel.Direction.In } => ParameterDirection.In(),
         { Direction: GirModel.Direction.Out } => ParameterDirection.Out(),
-        _ => throw new Exception($"records with direction '{parameter.Direction}' not yet supported")
+        _ => throw new Exception($"Typed records with direction '{parameter.Direction}' not yet supported")
     };
 }

--- a/src/Native/GirTestLib/girtest-typed-record-tester.c
+++ b/src/Native/GirTestLib/girtest-typed-record-tester.c
@@ -99,7 +99,7 @@ girtest_typed_record_tester_nullable_mirror(GirTestTypedRecordTester *data, gboo
 }
 
 /**
- * girtrest_typed_record_tester_unref:
+ * girtest_typed_record_tester_unref:
  * @self: (transfer full): a `GirTestTypedRecordTester`
  *
  * Decrements the reference count on `data` and frees the
@@ -222,6 +222,18 @@ int girtest_typed_record_tester_get_ref_count_sum_nullable(GirTestTypedRecordTes
         return -1;
 
     return girtest_typed_record_tester_get_ref_count_sum(data, size);
+}
+
+/**
+ * girtest_typed_record_tester_out_no_ownership_transfer_non_nullable_caller_allocates:
+ * @data: (not nullable) (out caller-allocates) (transfer none): a `GirTestTypedRecordTester`
+ **/
+void
+girtest_typed_record_tester_out_no_ownership_transfer_non_nullable_caller_allocates (GirTestTypedRecordTester *data)
+{
+    g_return_if_fail (data != NULL);
+
+    data->custom_string = g_strdup("OutParameter");
 }
 
 /**

--- a/src/Native/GirTestLib/girtest-typed-record-tester.h
+++ b/src/Native/GirTestLib/girtest-typed-record-tester.h
@@ -51,14 +51,14 @@ GType girtest_typed_record_tester_get_type (void) G_GNUC_CONST;
 /**
  * GirTestCreateTypedRecordTesterNoOwnershipTransfer:
  *
- * Returns: (transfer none): a new OpaqueRecordTester.
+ * Returns: (transfer none): a new TypedRecordTester.
  */
 typedef GirTestTypedRecordTester* (*GirTestCreateTypedRecordTesterNoOwnershipTransfer) ();
 
 /**
  * GirTestCreateTypedRecordTesterNoOwnershipTransferNullable:
  *
- * Returns: (transfer none) (nullable): a new OpaqueRecordTester or NULL.
+ * Returns: (transfer none) (nullable): a new TypedRecordTester or NULL.
  */
 typedef GirTestTypedRecordTester* (*GirTestCreateTypedRecordTesterNoOwnershipTransferNullable) ();
 
@@ -120,6 +120,7 @@ void girtest_typed_record_tester_take_and_unref_func(int dummy, GirTestTypedReco
 void girtest_typed_record_tester_take_and_unref_func_nullable(int dummy, GirTestTypedRecordTester *data);
 int girtest_typed_record_tester_get_ref_count_sum(GirTestTypedRecordTester * const *data, gsize size);
 int girtest_typed_record_tester_get_ref_count_sum_nullable(GirTestTypedRecordTester * const *data, gsize size);
+void girtest_typed_record_tester_out_no_ownership_transfer_non_nullable_caller_allocates(GirTestTypedRecordTester *data);
 GirTestTypedRecordTester * girtest_typed_record_tester_run_callback_return_no_ownership_transfer(GirTestCreateTypedRecordTesterNoOwnershipTransfer callback);
 GirTestTypedRecordTester * girtest_typed_record_tester_run_callback_return_no_ownership_transfer_nullable(GirTestCreateTypedRecordTesterNoOwnershipTransferNullable callback);
 GirTestTypedRecordTester * girtest_typed_record_tester_run_callback_return_full_ownership_transfer(GirTestCreateTypedRecordTesterFullOwnershipTransfer callback);

--- a/src/Tests/Libs/GirTest-0.1.Tests/TypedRecordTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/TypedRecordTest.cs
@@ -128,6 +128,13 @@ public class TypedRecordTest : Test
     }
 
     [TestMethod]
+    public void SupportsOutParameterNonNullableTransferNoneCallerAllocates()
+    {
+        TypedRecordTester.OutNoOwnershipTransferNonNullableCallerAllocates(out TypedRecordTester recordTester);
+        recordTester.CustomString.Should().Be("OutParameter");
+    }
+
+    [TestMethod]
     public void SupportsParameterArrayWithLengthParameter()
     {
         var recordTester1 = TypedRecordTester.New();


### PR DESCRIPTION
* Only non-nullable out parameters without ownership transfer for now
* Nullable out-parameters don't make much sense in C# in the traditional way
* Added new native test
* Fixed a few typos

See #1120, #1191 and #932 to see what part of them is solved by this.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
