### PR TITLE
For TaskCompletionSource use Try-methods to avoid invalid operation

### DIFF
--- a/src/Libs/Gdk-4.0/Public/Clipboard.cs
+++ b/src/Libs/Gdk-4.0/Public/Clipboard.cs
@@ -14,16 +14,16 @@ public partial class Clipboard
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var readValue = Internal.Clipboard.ReadTextFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else
-                tcs.SetResult(readValue.ConvertToString());
+                tcs.TrySetResult(readValue.ConvertToString());
         });
 
         Internal.Clipboard.ReadTextAsync(

--- a/src/Libs/Gio-2.0/Public/DBusConnection.cs
+++ b/src/Libs/Gio-2.0/Public/DBusConnection.cs
@@ -25,16 +25,16 @@ public partial class DBusConnection
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var ret = Internal.DBusConnection.CallFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GException(error));
+                tcs.TrySetException(new GException(error));
             else
-                tcs.SetResult(new Variant(ret));
+                tcs.TrySetResult(new Variant(ret));
         });
 
         Internal.DBusConnection.Call(Handle.DangerousGetHandle(),

--- a/src/Libs/Gtk-4.0/Public/AlertDialog.cs
+++ b/src/Libs/Gtk-4.0/Public/AlertDialog.cs
@@ -14,16 +14,16 @@ public partial class AlertDialog
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var chooseValue = Internal.AlertDialog.ChooseFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else
-                tcs.SetResult(chooseValue);
+                tcs.TrySetResult(chooseValue);
         });
 
         Internal.AlertDialog.Choose(

--- a/src/Libs/Gtk-4.0/Public/FileDialog.cs
+++ b/src/Libs/Gtk-4.0/Public/FileDialog.cs
@@ -14,18 +14,18 @@ public partial class FileDialog
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var fileValue = Internal.FileDialog.OpenFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else if (fileValue == IntPtr.Zero)
-                tcs.SetResult(null);
+                tcs.TrySetResult(null);
             else
-                tcs.SetResult((Gio.File) GObject.Internal.InstanceWrapper.WrapHandle<Gio.FileHelper>(fileValue, true));
+                tcs.TrySetResult((Gio.File) GObject.Internal.InstanceWrapper.WrapHandle<Gio.FileHelper>(fileValue, true));
         });
 
         Internal.FileDialog.Open(
@@ -48,18 +48,18 @@ public partial class FileDialog
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var listValue = Internal.FileDialog.OpenMultipleFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else if (listValue == IntPtr.Zero)
-                tcs.SetResult(null);
+                tcs.TrySetResult(null);
             else
-                tcs.SetResult((Gio.ListModel) GObject.Internal.InstanceWrapper.WrapHandle<Gio.ListModelHelper>(listValue, true));
+                tcs.TrySetResult((Gio.ListModel) GObject.Internal.InstanceWrapper.WrapHandle<Gio.ListModelHelper>(listValue, true));
         });
 
         Internal.FileDialog.OpenMultiple(
@@ -82,18 +82,18 @@ public partial class FileDialog
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var fileValue = Internal.FileDialog.SaveFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else if (fileValue == IntPtr.Zero)
-                tcs.SetResult(null);
+                tcs.TrySetResult(null);
             else
-                tcs.SetResult((Gio.File) GObject.Internal.InstanceWrapper.WrapHandle<Gio.FileHelper>(fileValue, true));
+                tcs.TrySetResult((Gio.File) GObject.Internal.InstanceWrapper.WrapHandle<Gio.FileHelper>(fileValue, true));
         });
 
         Internal.FileDialog.Save(
@@ -117,18 +117,18 @@ public partial class FileDialog
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var fileValue = Internal.FileDialog.SelectFolderFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else if (fileValue == IntPtr.Zero)
-                tcs.SetResult(null);
+                tcs.TrySetResult(null);
             else
-                tcs.SetResult((Gio.File) GObject.Internal.InstanceWrapper.WrapHandle<Gio.FileHelper>(fileValue, true));
+                tcs.TrySetResult((Gio.File) GObject.Internal.InstanceWrapper.WrapHandle<Gio.FileHelper>(fileValue, true));
         });
 
         Internal.FileDialog.SelectFolder(
@@ -151,18 +151,18 @@ public partial class FileDialog
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var listValue = Internal.FileDialog.SelectMultipleFoldersFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else if (listValue == IntPtr.Zero)
-                tcs.SetResult(null);
+                tcs.TrySetResult(null);
             else
-                tcs.SetResult((Gio.ListModel) GObject.Internal.InstanceWrapper.WrapHandle<Gio.ListModelHelper>(listValue, true));
+                tcs.TrySetResult((Gio.ListModel) GObject.Internal.InstanceWrapper.WrapHandle<Gio.ListModelHelper>(listValue, true));
         });
 
         Internal.FileDialog.SelectMultipleFolders(

--- a/src/Libs/Gtk-4.0/Public/FileLauncher.cs
+++ b/src/Libs/Gtk-4.0/Public/FileLauncher.cs
@@ -14,16 +14,16 @@ public partial class FileLauncher
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var launchValue = Internal.FileLauncher.LaunchFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else
-                tcs.SetResult(launchValue);
+                tcs.TrySetResult(launchValue);
         });
 
         Internal.FileLauncher.Launch(
@@ -46,16 +46,16 @@ public partial class FileLauncher
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var launchValue = Internal.FileLauncher.OpenContainingFolderFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else
-                tcs.SetResult(launchValue);
+                tcs.TrySetResult(launchValue);
         });
 
         Internal.FileLauncher.OpenContainingFolder(

--- a/src/Libs/Gtk-4.0/Public/FontDialog.cs
+++ b/src/Libs/Gtk-4.0/Public/FontDialog.cs
@@ -14,18 +14,18 @@ public partial class FontDialog
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var chooseFontFaceResult = Internal.FontDialog.ChooseFaceFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             if (chooseFontFaceResult == IntPtr.Zero)
-                tcs.SetResult(null);
+                tcs.TrySetResult(null);
             else
-                tcs.SetResult((Pango.FontFace) GObject.Internal.InstanceWrapper.WrapHandle<Pango.FontFace>(chooseFontFaceResult, true));
+                tcs.TrySetResult((Pango.FontFace) GObject.Internal.InstanceWrapper.WrapHandle<Pango.FontFace>(chooseFontFaceResult, true));
         });
 
         Internal.FontDialog.ChooseFace(
@@ -49,18 +49,18 @@ public partial class FontDialog
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var chooseFontFamilyResult = Internal.FontDialog.ChooseFamilyFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else if (chooseFontFamilyResult == IntPtr.Zero)
-                tcs.SetResult(null);
+                tcs.TrySetResult(null);
             else
-                tcs.SetResult((Pango.FontFamily) GObject.Internal.InstanceWrapper.WrapHandle<Pango.FontFamily>(chooseFontFamilyResult, true));
+                tcs.TrySetResult((Pango.FontFamily) GObject.Internal.InstanceWrapper.WrapHandle<Pango.FontFamily>(chooseFontFamilyResult, true));
         });
 
         Internal.FontDialog.ChooseFamily(
@@ -84,18 +84,18 @@ public partial class FontDialog
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var fontDescriptionOwnedHandle = Internal.FontDialog.ChooseFontFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else if (fontDescriptionOwnedHandle.IsInvalid)
-                tcs.SetResult(null);
+                tcs.TrySetResult(null);
             else
-                tcs.SetResult(new Pango.FontDescription(fontDescriptionOwnedHandle));
+                tcs.TrySetResult(new Pango.FontDescription(fontDescriptionOwnedHandle));
         });
 
         var initialValue = (Pango.Internal.FontDescriptionHandle?) fontDescription?.Handle ?? Pango.Internal.FontDescriptionUnownedHandle.NullHandle;

--- a/src/Libs/Gtk-4.0/Public/UriLauncher.cs
+++ b/src/Libs/Gtk-4.0/Public/UriLauncher.cs
@@ -14,16 +14,16 @@ public partial class UriLauncher
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var launchValue = Internal.UriLauncher.LaunchFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else
-                tcs.SetResult(launchValue);
+                tcs.TrySetResult(launchValue);
         });
 
         Internal.UriLauncher.Launch(

--- a/src/Libs/WebKit-6.0/Public/WebView.cs
+++ b/src/Libs/WebKit-6.0/Public/WebView.cs
@@ -14,16 +14,16 @@ public partial class WebView
         {
             if (sourceObject is null)
             {
-                tcs.SetException(new Exception("Missing source object"));
+                tcs.TrySetException(new Exception("Missing source object"));
                 return;
             }
 
             var jsValue = Internal.WebView.EvaluateJavascriptFinish(sourceObject.Handle.DangerousGetHandle(), res.Handle.DangerousGetHandle(), out var error);
 
             if (!error.IsInvalid)
-                tcs.SetException(new GLib.GException(error));
+                tcs.TrySetException(new GLib.GException(error));
             else
-                tcs.SetResult((JavaScriptCore.Value) GObject.Internal.InstanceWrapper.WrapHandle<JavaScriptCore.Value>(jsValue, true));
+                tcs.TrySetResult((JavaScriptCore.Value) GObject.Internal.InstanceWrapper.WrapHandle<JavaScriptCore.Value>(jsValue, true));
         });
 
         Internal.WebView.EvaluateJavascript(


### PR DESCRIPTION
- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

So far the `SetResult`, etc. methods are used and this can result in
```
System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
   at System.Threading.Tasks.TaskCompletionSource`1.SetResult(TResult result)
   at Gtk.FontDialog.<>c__DisplayClass1_0.<ChooseFaceAsync>b__0(Object sourceObject, AsyncResult res, IntPtr data)
   at Gio.Internal.AsyncReadyCallbackAsyncHandler.<.ctor>b__3_0(IntPtr sourceObject, IntPtr res, IntPtr data)
   at Gio.Internal.Application.Run(IntPtr application, Int32 argc, String[] argv)
   at Gio.Application.Run(Int32 argc, String[] argv)
   at Gio.Application.RunWithSynchronizationContext(String[] args)
   at Program.<Main>$(String[] args)
```
when it is tried to call the Set-method more than once. Here with a FontDialog that is "Cancel"led by user.
Looking at the implementation I don't see a bug here, so maybe the native side invokes the callback more than once.

Anyway, by using the `TrySet`-methods on TCS this won't happen.