### PR TITLE
First steps to support GLib.PtrArray

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/ReturnType/Converter/GLibPointerArray.cs
+++ b/src/Generation/Generator/Renderer/Internal/ReturnType/Converter/GLibPointerArray.cs
@@ -1,0 +1,20 @@
+namespace Generator.Renderer.Internal.ReturnType;
+
+internal class GLibPointerArray : ReturnTypeConverter
+{
+    public bool Supports(GirModel.ReturnType returnType)
+    {
+        return returnType.AnyType.IsGLibPtrArray();
+    }
+
+    public RenderableReturnType Convert(GirModel.ReturnType returnType)
+    {
+        var typeName = returnType switch
+        {
+            { Transfer: GirModel.Transfer.Full } => "GLib.Internal.PtrArrayOwnedHandle",
+            _ => "GLib.Internal.PtrArrayUnownedHandle"
+        };
+
+        return new RenderableReturnType(typeName);
+    }
+}

--- a/src/Generation/Generator/Renderer/Internal/ReturnType/ReturnTypeRenderer.cs
+++ b/src/Generation/Generator/Renderer/Internal/ReturnType/ReturnTypeRenderer.cs
@@ -4,13 +4,14 @@ namespace Generator.Renderer.Internal;
 
 internal static class ReturnTypeRenderer
 {
-    private static readonly List<ReturnType.ReturnTypeConverter> converters = new()
-    {
+    private static readonly List<ReturnType.ReturnTypeConverter> converters =
+    [
         new ReturnType.Bitfield(),
         new ReturnType.Class(),
         new ReturnType.ClassArray(),
         new ReturnType.Enumeration(),
         new ReturnType.ForeignTypedRecord(),
+        new ReturnType.GLibPointerArray(),
         new ReturnType.Interface(),
         new ReturnType.InterfaceGLibPtrArray(),
         new ReturnType.OpaqueTypedRecord(),
@@ -33,8 +34,8 @@ internal static class ReturnTypeRenderer
         new ReturnType.UntypedRecord(),
         new ReturnType.Utf8String(),
         new ReturnType.Utf8StringArray(),
-        new ReturnType.Void(),
-    };
+        new ReturnType.Void()
+    ];
 
     public static string Render(GirModel.ReturnType returnType)
     {

--- a/src/Generation/Generator/Renderer/Public/ReturnType/Converter/GLibPointerArray.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnType/Converter/GLibPointerArray.cs
@@ -1,0 +1,16 @@
+using Generator.Model;
+
+namespace Generator.Renderer.Public.ReturnType;
+
+internal class GLibPointerArray : ReturnTypeConverter
+{
+    public bool Supports(GirModel.ReturnType returnType)
+    {
+        return returnType.AnyType.IsGLibPtrArray();
+    }
+
+    public RenderableReturnType Create(GirModel.ReturnType returnType)
+    {
+        return new RenderableReturnType("GLib.PtrArray" + Nullable.Render(returnType));
+    }
+}

--- a/src/Generation/Generator/Renderer/Public/ReturnType/ReturnTypeRenderer.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnType/ReturnTypeRenderer.cs
@@ -11,6 +11,7 @@ internal static class ReturnTypeRenderer
         new ReturnType.Class(),
         new ReturnType.Enumeration(),
         new ReturnType.ForeignTypedRecord(),
+        new ReturnType.GLibPointerArray(),
         new ReturnType.Interface(),
         new ReturnType.OpaqueTypedRecord(),
         new ReturnType.OpaqueUntypedRecord(),

--- a/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/GLibPointerArray.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/Converter/GLibPointerArray.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using GirModel;
+
+namespace Generator.Renderer.Public.ReturnTypeToManagedExpressions;
+
+internal class GLibPointerArray : ReturnTypeConverter
+{
+    public bool Supports(AnyType type)
+    {
+        return type.IsGLibPtrArray();
+    }
+
+    public void Initialize(ReturnTypeToManagedData data, IEnumerable<ParameterToNativeData> _)
+    {
+        data.SetExpression(fromVariableName =>
+        {
+            var returnType = data.ReturnType;
+
+            var handleExpression = returnType switch
+            {
+                { Transfer: Transfer.Full } => fromVariableName,
+                { Transfer: Transfer.None } => $"{fromVariableName}.OwnedCopy()",
+                _ => throw new NotImplementedException("Unknown transfer type")
+            };
+
+            var createNewInstance = $"new GLib.PtrArray({handleExpression})";
+
+            return returnType.Nullable
+                 ? $"{fromVariableName}.IsInvalid ? null : {createNewInstance}"
+                 : createNewInstance;
+        });
+    }
+}

--- a/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/ReturnTypeToManagedExpression.cs
+++ b/src/Generation/Generator/Renderer/Public/ReturnTypeToManagedExpression/ReturnTypeToManagedExpression.cs
@@ -10,6 +10,7 @@ internal static class ReturnTypeToManagedExpression
         new ReturnTypeToManagedExpressions.Class(),
         new ReturnTypeToManagedExpressions.Enumeration(),
         new ReturnTypeToManagedExpressions.ForeignTypedRecord(),
+        new ReturnTypeToManagedExpressions.GLibPointerArray(),
         new ReturnTypeToManagedExpressions.Interface(),
         new ReturnTypeToManagedExpressions.OpaqueTypedRecord(),
         new ReturnTypeToManagedExpressions.OpaqueUntypedRecord(),

--- a/src/Tests/Libs/GLib-2.0.Tests/Records/PtrArrayTest.cs
+++ b/src/Tests/Libs/GLib-2.0.Tests/Records/PtrArrayTest.cs
@@ -1,0 +1,15 @@
+using AwesomeAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GLib.Tests;
+
+[TestClass, TestCategory("UnitTest")]
+public class PtrArrayTest
+{
+    [TestMethod]
+    public void CanCreateNewPtrArray()
+    {
+        var ptrArray = PtrArray.New();
+        ptrArray.Len.Should().Be(0);
+    }
+}


### PR DESCRIPTION
- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

First steps to support GLib.PtrArray. Part of #748 (Planned for 0.9.0).

This came up through: #1344 

@alansartorio: This allows to use `GLib.PtrArray.New()`. But to access or work with the data there needs to be some manual implementation. Perhaps you can create extension methods or similar. If you are interested feel free to contribute directly to GirCore to improve the PtrArray scenario.