### PR TITLE
Added GirCore1005 analyser

### DIFF
--- a/src/Extensions/GObject-2.0.Integration/SourceAnalyzer/Analyzer.cs
+++ b/src/Extensions/GObject-2.0.Integration/SourceAnalyzer/Analyzer.cs
@@ -12,7 +12,8 @@ public class Analyzer : DiagnosticAnalyzer
         GirCore1001.DiagnosticDescriptor,
         GirCore1002.DiagnosticDescriptor,
         GirCore1003.DiagnosticDescriptor,
-        GirCore1004.DiagnosticDescriptor
+        GirCore1004.DiagnosticDescriptor,
+        GirCore1005.DiagnosticDescriptor,
     ];
 
     public override void Initialize(AnalysisContext context)
@@ -24,6 +25,7 @@ public class Analyzer : DiagnosticAnalyzer
         RegisterDiagnosticRule<GirCore1002>(context);
         RegisterDiagnosticRule<GirCore1003>(context);
         RegisterDiagnosticRule<GirCore1004>(context);
+        RegisterDiagnosticRule<GirCore1005>(context);
     }
 
     private static void RegisterDiagnosticRule<T>(AnalysisContext context) where T : Rule

--- a/src/Extensions/GObject-2.0.Integration/SourceAnalyzer/Rules/GirCore1005.cs
+++ b/src/Extensions/GObject-2.0.Integration/SourceAnalyzer/Rules/GirCore1005.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace GObject.Integration.SourceAnalyzer;
+
+internal sealed class GirCore1005 : Rule
+{
+    public static SyntaxKind SyntaxKind => SyntaxKind.ClassDeclaration;
+
+    public static DiagnosticDescriptor DiagnosticDescriptor { get; } = new(
+        id: "GirCore1005",
+        title: "GObject subclass may not be nested inside a generic type",
+        messageFormat: "GObject subclass must not be declared inside a generic type. Use a regular subclass (without SubclassAttribute) or extension blocks to allow type safe access to data.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        helpLinkUri: DiagnosticLink.Create(1005)
+    );
+
+    public static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var classDeclarationSyntax = (ClassDeclarationSyntax) context.Node;
+
+        var classSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclarationSyntax);
+        if (classSymbol is null || !classSymbol.GetAttributes().Any(x => x.IsSubclassAttribute()))
+            return;
+
+        TypeDeclarationSyntax? syntax = classDeclarationSyntax.Parent as ClassDeclarationSyntax;
+        while (syntax is not null)
+        {
+            if (syntax.Arity > 0)
+            {
+                var diagnostic = Diagnostic.Create(DiagnosticDescriptor, classDeclarationSyntax.GetLocation());
+                context.ReportDiagnostic(diagnostic);
+                return;
+            }
+
+            syntax = syntax.Parent as ClassDeclarationSyntax;
+        }
+
+    }
+}

--- a/src/Tests/Libs/GObject-2.0.Integration.Tests/DiagnosticAnalyzerTest.cs
+++ b/src/Tests/Libs/GObject-2.0.Integration.Tests/DiagnosticAnalyzerTest.cs
@@ -40,6 +40,19 @@ public class DiagnosticAnalyzerTest : Test
                                             public partial class RaiseGirCore1004<T>;
                                             """;
 
+    private const string RaiseGirCore1005 = """
+                                            public partial class Wrapper<T>
+                                            {
+                                                [GObject.Subclass<GObject.Object>]
+                                                public partial class RaiseGirCore1004Wrapped
+                                                {
+                                                    public RaiseGirCore1004Wrapped() : this()
+                                                    {
+                                                    }
+                                                }
+                                            }
+                                            """;
+
     private const string NotRaiseGirCore1002 = """
                                                [GObject.Subclass<GObject.Object>]
                                                public partial class NotRaiseGirCore1002
@@ -60,8 +73,11 @@ public class DiagnosticAnalyzerTest : Test
     [DataRow(RaiseGirCore1002, "GirCore1002", true)]
     [DataRow(RaiseGirCore1003, "GirCore1003", true)]
     [DataRow(RaiseGirCore1004, "GirCore1004", true)]
+    [DataRow(RaiseGirCore1005, "GirCore1005", true)]
     [DataRow(NotRaiseGirCore1002, "GirCore1002", false)]
     [DataRow(NotRaiseGirCore1004, "GirCore1004", false)]
+    [DataRow(RaiseGirCore1005, "GirCore1004", false)]
+    [DataRow(RaiseGirCore1004, "GirCore1005", false)]
     public async Task ShouldRaiseExpectedDiagnosticIds(string code, string diagnosticId, bool diagnosticIdExpected)
     {
         var compilation = CSharpCompilation.Create(


### PR DESCRIPTION
Due to the overlap (adjacency, really) with GirCore1004, I added unit tests to ensure that classes which would emit GirCore1004 don't emit GirCore1005, and vice versa. Not sure if this is strictly necessary - I left it in for now but am happy to remove it.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
