### PR TITLE
Generate enum "out" and "ref" parameters

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/Parameter/Converter/Enumeration.cs
+++ b/src/Generation/Generator/Renderer/Internal/Parameter/Converter/Enumeration.cs
@@ -17,17 +17,22 @@ internal class Enumeration : ParameterConverter
         );
     }
 
-    private static string GetNullableTypeName(GirModel.Parameter parameter) => parameter.IsPointer switch
+    private static string GetNullableTypeName(GirModel.Parameter parameter)
     {
-        true => Model.Type.Pointer,
-        false => Model.ComplexType.GetFullyQualified((GirModel.Enumeration) parameter.AnyTypeOrVarArgs.AsT0.AsT0)
-    };
+        return parameter switch
+        {
+            { Direction: GirModel.Direction.Out, IsPointer: true } => Model.ComplexType.GetFullyQualified((GirModel.Enumeration) parameter.AnyTypeOrVarArgs.AsT0.AsT0),
+            { Direction: GirModel.Direction.InOut, IsPointer: true } => Model.ComplexType.GetFullyQualified((GirModel.Enumeration) parameter.AnyTypeOrVarArgs.AsT0.AsT0),
+            { IsPointer: true } => Model.Type.Pointer,
+            _ => Model.ComplexType.GetFullyQualified((GirModel.Enumeration) parameter.AnyTypeOrVarArgs.AsT0.AsT0)
+        };
+    }
 
     private static string GetDirection(GirModel.Parameter parameter) => parameter switch
     {
-        { Direction: GirModel.Direction.InOut } => ParameterDirection.Ref(),
-        { Direction: GirModel.Direction.Out, CallerAllocates: true } => ParameterDirection.Ref(),
-        { Direction: GirModel.Direction.Out } => ParameterDirection.Out(),
+        { Direction: GirModel.Direction.InOut, IsPointer: true } => ParameterDirection.Ref(),
+        { Direction: GirModel.Direction.Out, IsPointer: true, CallerAllocates: true } => ParameterDirection.Ref(),
+        { Direction: GirModel.Direction.Out, IsPointer: true } => ParameterDirection.Out(),
         _ => ParameterDirection.In()
     };
 }

--- a/src/Generation/Generator/Renderer/Internal/ParameterToManagedExpression/Converter/Enumeration.cs
+++ b/src/Generation/Generator/Renderer/Internal/ParameterToManagedExpression/Converter/Enumeration.cs
@@ -8,13 +8,46 @@ internal class Enumeration : ToManagedParameterConverter
     public bool Supports(GirModel.AnyType type)
         => type.Is<GirModel.Enumeration>();
 
-    public void Initialize(ParameterToManagedData parameterData, IEnumerable<ParameterToManagedData> parameters)
+    public void Initialize(ParameterToManagedData parameter, IEnumerable<ParameterToManagedData> parameters)
     {
-        if (parameterData.Parameter.Direction != GirModel.Direction.In)
-            throw new NotImplementedException($"{parameterData.Parameter.AnyTypeOrVarArgs}: Enumeration with direction != in not yet supported");
+        switch (parameter.Parameter)
+        {
+            case { Direction: GirModel.Direction.In, IsPointer: false }:
+                Direct(parameter);
+                break;
+            case { Direction: GirModel.Direction.InOut, IsPointer: true }:
+            case { Direction: GirModel.Direction.Out, IsPointer: true, CallerAllocates: true }:
+                Ref(parameter);
+                break;
+            case { Direction: GirModel.Direction.Out, IsPointer: true }:
+                Out(parameter);
+                break;
+            default:
+                throw new NotImplementedException($"{parameter.Parameter.AnyTypeOrVarArgs}: This kind of enumeration (pointed: {parameter.Parameter.IsPointer}, direction: {parameter.Parameter.Direction} can't be converted to managed currently.");
+        }
+    }
 
+    private static void Ref(ParameterToManagedData parameterData)
+    {
         var variableName = Model.Parameter.GetName(parameterData.Parameter);
+
+        parameterData.SetSignatureName(() => variableName);
+        parameterData.SetCallName(() => $"ref {variableName}");
+    }
+
+    private static void Direct(ParameterToManagedData parameterData)
+    {
+        var variableName = Model.Parameter.GetName(parameterData.Parameter);
+
         parameterData.SetSignatureName(() => variableName);
         parameterData.SetCallName(() => variableName);
+    }
+
+    private static void Out(ParameterToManagedData parameterData)
+    {
+        var variableName = Model.Parameter.GetName(parameterData.Parameter);
+
+        parameterData.SetSignatureName(() => variableName);
+        parameterData.SetCallName(() => $"out {variableName}");
     }
 }

--- a/src/Native/GirTestLib/girtest-callback-tester.c
+++ b/src/Native/GirTestLib/girtest-callback-tester.c
@@ -346,3 +346,39 @@ girtest_callback_tester_run_callback_with_object_return_transfer_none(GirTestTra
     GObject* obj = callback();
     return obj->ref_count;
 }
+
+/**
+ * girtest_callback_tester_run_callback_enum_out:
+ * @callback: (scope call): a function that is called and has an enum out parameter.
+ *
+ * Calls the callback. 
+ *
+ * Returns: The enum value assigned to the out parameter by the callback `GirTestEnumOutCallback`.
+ **/
+GirTestCallbackTesterSimpleEnum
+girtest_callback_tester_run_callback_enum_out(GirTestEnumOutCallback callback)
+{
+    GirTestCallbackTesterSimpleEnum e = 0;
+
+    callback(&e);
+
+    return e;
+}
+
+/**
+ * girtest_callback_tester_run_callback_enum_ref:
+ * @callback: (scope call): a function that is called and has an enum ref parameter.
+ *
+ * Calls the callback. 
+ *
+ * Returns: The enum value assigned to the ref parameter by the callback `GirTestEnumRefCallback`.
+ **/
+GirTestCallbackTesterSimpleEnum
+girtest_callback_tester_run_callback_enum_ref(GirTestEnumRefCallback callback)
+{
+    GirTestCallbackTesterSimpleEnum e = SIMPLE_ENUM_A;
+
+    callback(&e);
+
+    return e;
+}

--- a/src/Native/GirTestLib/girtest-callback-tester.h
+++ b/src/Native/GirTestLib/girtest-callback-tester.h
@@ -89,6 +89,26 @@ typedef GObject* (*GirTestTransferFullObjectReturnCallback) ();
  */
 typedef GObject* (*GirTestTransferNoneObjectReturnCallback) ();
 
+typedef enum {
+    SIMPLE_ENUM_A = 1,
+    SIMPLE_ENUM_B = 2,
+    SIMPLE_ENUM_C = 3,
+    SIMPLE_ENUM_MAX = 2147483647,
+    SIMPLE_ENUM_MIN = -2147483648
+} GirTestCallbackTesterSimpleEnum;
+
+/**
+ * GirTestEnumOutCallback:
+ * @e: (out): return location for an enum
+ */
+typedef void (*GirTestEnumOutCallback) (GirTestCallbackTesterSimpleEnum *e);
+
+/**
+ * GirTestEnumRefCallback:
+ * @e: (inout): input and return location for an enum
+ */
+typedef void (*GirTestEnumRefCallback) (GirTestCallbackTesterSimpleEnum *e);
+
 GirTestCallbackTester*
 girtest_callback_tester_new (void);
 
@@ -153,5 +173,11 @@ girtest_callback_tester_run_callback_with_object_return_transfer_full(GirTestTra
 
 guint
 girtest_callback_tester_run_callback_with_object_return_transfer_none(GirTestTransferNoneObjectReturnCallback callback);
+
+GirTestCallbackTesterSimpleEnum
+girtest_callback_tester_run_callback_enum_out(GirTestEnumOutCallback callback);
+
+GirTestCallbackTesterSimpleEnum
+girtest_callback_tester_run_callback_enum_ref(GirTestEnumRefCallback callback);
 
 G_END_DECLS

--- a/src/Native/GirTestLib/girtest-enum-tester.c
+++ b/src/Native/GirTestLib/girtest-enum-tester.c
@@ -22,3 +22,24 @@ static void
 girtest_enum_tester_class_init(GirTestEnumTesterClass *class)
 {
 }
+
+/**
+ * girtest_enum_tester_out_parameter:
+ * @out_enum: (out): location to store a #GirTestEnumTesterSimpleEnum or %NULL
+ **/
+void girtest_enum_tester_out_parameter(GirTestEnumTesterSimpleEnum *out_enum)
+{
+	if (out_enum)
+		*out_enum = SIMPLE_ENUM_A;
+}
+
+/**
+ * girtest_enum_tester_ref_parameter:
+ * @ref_enum: (inout): location to store a #GirTestEnumTesterSimpleEnum or %NULL
+ **/
+void girtest_enum_tester_ref_parameter(GirTestEnumTesterSimpleEnum *ref_enum)
+{
+	// Change A (input) to B (output)
+	if (ref_enum && *ref_enum == SIMPLE_ENUM_A)
+		*ref_enum = SIMPLE_ENUM_B;
+}

--- a/src/Native/GirTestLib/girtest-enum-tester.h
+++ b/src/Native/GirTestLib/girtest-enum-tester.h
@@ -24,6 +24,9 @@ typedef enum {
 
 #define GIRTEST_TYPE_ENUM_TESTER girtest_enum_tester_get_type()
 
+void girtest_enum_tester_out_parameter(GirTestEnumTesterSimpleEnum *out_enum);
+void girtest_enum_tester_ref_parameter(GirTestEnumTesterSimpleEnum *ref_enum);
+
 G_DECLARE_FINAL_TYPE(GirTestEnumTester, girtest_enum_tester, GIRTEST, ENUM_TESTER, GObject)
 
 G_END_DECLS

--- a/src/Tests/Libs/GirTest-0.1.Tests/CallbackTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/CallbackTest.cs
@@ -292,4 +292,29 @@ public class CallbackTest : Test
         refCount.Should().Be(1);
         GObject.Internal.InstanceCache.ObjectCount.Should().Be(1); //ExecutorImpl instance
     }
+
+    [TestMethod]
+    public void SupportsCallbackWithEnumOutParameter()
+    {
+        void Callback(out CallbackTesterSimpleEnum e)
+        {
+            e = CallbackTesterSimpleEnum.Max;
+        }
+
+        var result = CallbackTester.RunCallbackEnumOut(Callback);
+        result.Should().Be(CallbackTesterSimpleEnum.Max);
+    }
+
+    [TestMethod]
+    public void SupportsCallbackWithEnumRefParameter()
+    {
+        void Callback(ref CallbackTesterSimpleEnum e)
+        {
+            if (e == CallbackTesterSimpleEnum.A)
+                e = CallbackTesterSimpleEnum.B;
+        }
+
+        var result = CallbackTester.RunCallbackEnumRef(Callback);
+        result.Should().Be(CallbackTesterSimpleEnum.B);
+    }
 }

--- a/src/Tests/Libs/GirTest-0.1.Tests/EnumerationTest.cs
+++ b/src/Tests/Libs/GirTest-0.1.Tests/EnumerationTest.cs
@@ -34,4 +34,20 @@ public class EnumerationTest : Test
         value.GetEnum().Should().Be(1 << 31);
         value.GetEnum<EnumTesterSimpleEnum>().Should().Be(EnumTesterSimpleEnum.Min);
     }
+
+    [TestMethod]
+    public void OutParameter()
+    {
+        EnumTester.OutParameter(out EnumTesterSimpleEnum simpleEnum);
+        simpleEnum.Should().Be(EnumTesterSimpleEnum.A);
+    }
+
+    [TestMethod]
+    public void RefParameter()
+    {
+        var simpleEnum = EnumTesterSimpleEnum.A;
+        EnumTester.RefParameter(ref simpleEnum);
+
+        simpleEnum.Should().Be(EnumTesterSimpleEnum.B);
+    }
 }


### PR DESCRIPTION
Allow generating methods/functions that use enums as "out" or "ref" parameters.

New girtest functions for EnumerationTest:
- girtest_enum_tester_out_parameter
- girtest_enum_tester_ref_parameter

Example of previously missing method:
```
ScrolledWindow.GetPolicy:
- GirModel.AnyType: GirModel.Type: GirLoader.Output.Enumeration: Enumeration with direction != in not yet supported
```

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
