### PR TITLE
Instance creation: Fix regression

### DIFF
--- a/src/Generation/Generator/Renderer/Public/Class/ClassFramework.cs
+++ b/src/Generation/Generator/Renderer/Public/Class/ClassFramework.cs
@@ -99,9 +99,14 @@ public {@sealed}partial class {cls.Name} {RenderInheritance(cls)}
 
     private static string RenderUnref(GirModel.Class cls)
     {
+        /*
+         * Why RefSink?
+         * Gtk.Button: Floating after creation -> gets sunk. 
+         * Gtk.Window: Not floating after creation, because GTK owns a ref -> Ref count increased by 1 (implicit no ownership transfer)
+         */
         return Class.IsInitiallyUnowned(cls)
             ? """
-              GObject.Internal.Object.TakeRef(ptr);
+              GObject.Internal.Object.RefSink(ptr);
               GObject.Internal.Object.Unref(ptr);
               """
             : "GObject.Internal.Object.Unref(ptr);";
@@ -109,10 +114,15 @@ public {@sealed}partial class {cls.Name} {RenderInheritance(cls)}
 
     private static string RenderUnrefLegacy(GirModel.Class cls)
     {
+        /*
+         * Why RefSink?
+         * Gtk.Button: Floating after creation -> gets sunk.
+         * Gtk.Window: Not floating after creation, because GTK owns a ref -> Ref count increased by 1 (implicit no ownership transfer)
+         */
         return Class.IsInitiallyUnowned(cls)
             ? """
               var ptr = obj.Handle.DangerousGetHandle();
-              GObject.Internal.Object.TakeRef(ptr);
+              GObject.Internal.Object.RefSink(ptr);
               GObject.Internal.Object.Unref(ptr);
               """
             : "GObject.Internal.Object.Unref(obj.Handle.DangerousGetHandle());";

--- a/src/Integrations/GObject-2.0.Integration/SourceGenerator/Subclass/SubclassCode.cs
+++ b/src/Integrations/GObject-2.0.Integration/SourceGenerator/Subclass/SubclassCode.cs
@@ -199,9 +199,15 @@ internal static class SubclassCode
          * - Initially unowned objects have a floating reference which must be sunk and then removed
          */
 
+        /*
+         * Why RefSink?
+         * Gtk.Button: Floating after creation -> gets sunk.
+         * Gtk.Window: Not floating after creation, because GTK owns a ref -> Ref count increased by 1 (implicit no ownership transfer)
+         */
+
         return subclassData.IsInitiallyUnowned
             ? """
-              GObject.Internal.Object.TakeRef(ptr);
+              GObject.Internal.Object.RefSink(ptr);
               GObject.Internal.Object.Unref(ptr);
               """
             : "GObject.Internal.Object.Unref(ptr);";


### PR DESCRIPTION
InitiallyUnowned classes must not only be sunk: GTK behaves differently for Buttons / Windows.

It is required to call "ref_sink" because GTK sinks and takes a ref for top level widgets. In this case "ref_sink" increases the reference count. Which is like an implicit "transfer:none"

Other widgets are simply floating: "ref_sink" does nothing to them. This behaves like an implicit "transfer:full".

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
