### PR TITLE
Generator: Remove protected member in interface implementation

### DIFF
--- a/src/Generation/Generator/Renderer/Public/InterfaceImplementation/InterfaceImplementationFramework.cs
+++ b/src/Generation/Generator/Renderer/Public/InterfaceImplementation/InterfaceImplementationFramework.cs
@@ -22,7 +22,7 @@ namespace {Model.Namespace.GetPublicName(@interface.Namespace)};
 {PlatformSupportAttribute.Render(@interface as GirModel.PlatformDependent)}
 public sealed partial class {interfaceName} : {GetParent(@interface)}, {@interface.Name}, GObject.InstanceFactory
 {{
-    protected internal {interfaceName}({GetParentHandle(@interface)} handle) : base(handle) {{ }}
+    internal {interfaceName}({GetParentHandle(@interface)} handle) : base(handle) {{ }}
 
     /// <summary>
     /// Creates a new managed {interfaceName} instance for a given pointer.


### PR DESCRIPTION
Interface implementations are always sealed and can't be inherited. This fixes a compiler warning.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
