### PR TITLE
Generator hintName collision

### DIFF
--- a/src/Integrations/Shared/Type/TypeDataHelper.cs
+++ b/src/Integrations/Shared/Type/TypeDataHelper.cs
@@ -25,10 +25,19 @@ internal static class TypeDataHelper
 
     private static string GetFileName(INamedTypeSymbol typeSymbol)
     {
+        var namespacePrefix = GetNamespacePrefix(typeSymbol);
         var prefix = GetFileNamePrefix(typeSymbol);
         var suffix = typeSymbol.Arity == 0 ? string.Empty : $"_{typeSymbol.Arity}";
 
-        return prefix + typeSymbol.Name + suffix;
+        return namespacePrefix + prefix + typeSymbol.Name + suffix;
+    }
+
+    private static string GetNamespacePrefix(INamedTypeSymbol typeSymbol)
+    {
+        if (typeSymbol.ContainingNamespace.IsGlobalNamespace)
+            return string.Empty;
+
+        return typeSymbol.ContainingNamespace.ToDisplayString() + ".";
     }
 
     private static string GetFileNamePrefix(ISymbol typeSymbol)

--- a/src/Tests/Libs/GObject-2.0.Integration.Tests/DiagnosticAnalyzerTest.cs
+++ b/src/Tests/Libs/GObject-2.0.Integration.Tests/DiagnosticAnalyzerTest.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -65,6 +66,24 @@ public class DiagnosticAnalyzerTest : Test
                                                public class NotRaiseGirCore1004<T> : NotRaiseGirCore1004;
                                                """;
 
+    private const string DuplicateSubclassNameOne = """
+                                                    using GObject;
+
+                                                    namespace DuplicateSubclassName.One;
+
+                                                    [Subclass<GObject.Object>]
+                                                    public partial class Widget;
+                                                    """;
+
+    private const string DuplicateSubclassNameTwo = """
+                                                    using GObject;
+
+                                                    namespace DuplicateSubclassName.Two;
+
+                                                    [Subclass<GObject.Object>]
+                                                    public partial class Widget;
+                                                    """;
+
     [TestMethod]
     [DataRow(RaiseGirCore1002, "GirCore1002", true)]
     [DataRow(RaiseGirCore1004, "GirCore1004", true)]
@@ -99,5 +118,39 @@ public class DiagnosticAnalyzerTest : Test
             diagnostics.ContainsDiagnostic(diagnosticId);
         else
             diagnostics.ContainsNoDiagnostic(diagnosticId);
+    }
+
+    [TestMethod]
+    public void ShouldGenerateNamespaceQualifiedHintNamesForDuplicateSubclassNames()
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName: nameof(ShouldGenerateNamespaceQualifiedHintNamesForDuplicateSubclassNames),
+            syntaxTrees: [
+                CSharpSyntaxTree.ParseText(DuplicateSubclassNameOne),
+                CSharpSyntaxTree.ParseText(DuplicateSubclassNameTwo)
+            ],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            references: [
+                MetadataReference.CreateFromFile(System.Reflection.Assembly.Load("System.Runtime").Location),
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(GObject.Object).Assembly.Location)
+            ]
+        );
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new SourceGenerator.Generator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out var generatorDiagnostics, TestContext.CancellationToken);
+
+        generatorDiagnostics.ContainsNoDiagnostic("CS8785");
+
+        var generatedHintNames = driver
+            .GetRunResult()
+            .Results
+            .SelectMany(x => x.GeneratedSources)
+            .Select(x => x.HintName)
+            .ToList();
+
+        CollectionAssert.Contains(generatedHintNames, "DuplicateSubclassName.One.Widget.Subclass.g.cs");
+        CollectionAssert.Contains(generatedHintNames, "DuplicateSubclassName.Two.Widget.Subclass.g.cs");
+        CollectionAssert.AllItemsAreUnique(generatedHintNames);
     }
 }

--- a/src/Tests/Libs/Gtk-4.0.Integration.Tests/DiagnosticAnalyzerTest.cs
+++ b/src/Tests/Libs/Gtk-4.0.Integration.Tests/DiagnosticAnalyzerTest.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -51,6 +52,22 @@ public class DiagnosticAnalyzerTest : Test
                                             }
                                             """;
 
+    private const string DuplicateTemplateNameOne = """
+                                                    namespace DuplicateTemplateName.One;
+
+                                                    [GObject.Subclass<Gtk.Widget>]
+                                                    [Gtk.Template<Gtk.AssemblyResource>("CompositeBoxWidget.ui")]
+                                                    public partial class Widget;
+                                                    """;
+
+    private const string DuplicateTemplateNameTwo = """
+                                                    namespace DuplicateTemplateName.Two;
+
+                                                    [GObject.Subclass<Gtk.Widget>]
+                                                    [Gtk.Template<Gtk.AssemblyResource>("CompositeBoxWidget.ui")]
+                                                    public partial class Widget;
+                                                    """;
+
     [TestMethod]
     [DataRow(RaiseGirCore2001, "GirCore2001", true)]
     [DataRow(NotRaiseGirCore2001, "GirCore2001", false)]
@@ -83,5 +100,40 @@ public class DiagnosticAnalyzerTest : Test
             diagnostics.ContainsDiagnostic(diagnosticId);
         else
             diagnostics.ContainsNoDiagnostic(diagnosticId);
+    }
+
+    [TestMethod]
+    public void ShouldGenerateNamespaceQualifiedHintNamesForDuplicateTemplateNames()
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName: nameof(ShouldGenerateNamespaceQualifiedHintNamesForDuplicateTemplateNames),
+            syntaxTrees: [
+                CSharpSyntaxTree.ParseText(DuplicateTemplateNameOne),
+                CSharpSyntaxTree.ParseText(DuplicateTemplateNameTwo)
+            ],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            references: [
+                MetadataReference.CreateFromFile(System.Reflection.Assembly.Load("System.Runtime").Location),
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(GObject.Object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Gtk.Widget).Assembly.Location)
+            ]
+        );
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new SourceGenerator.Generator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out var generatorDiagnostics, TestContext.CancellationToken);
+
+        generatorDiagnostics.ContainsNoDiagnostic("CS8785");
+
+        var generatedHintNames = driver
+            .GetRunResult()
+            .Results
+            .SelectMany(x => x.GeneratedSources)
+            .Select(x => x.HintName)
+            .ToList();
+
+        CollectionAssert.Contains(generatedHintNames, "DuplicateTemplateName.One.Widget.Template.g.cs");
+        CollectionAssert.Contains(generatedHintNames, "DuplicateTemplateName.Two.Widget.Template.g.cs");
+        CollectionAssert.AllItemsAreUnique(generatedHintNames);
     }
 }


### PR DESCRIPTION
- [X] I agree that my contribution may be licensed either under MIT or any version of LGPL license.

Include the namespace in generated source filenames to avoid hintName collisions when different namespaces contain types with the same short name.

The filename generation in TypeDataHelper is now namespace-aware while keeping nested type names and generic parameter counts as part of the generated name.

This prevents AddSource collisions in source generators that use TypeData.Filename, including the GObject subclass generator and the GTK template generator.

Tests were added for both GObject and GTK integration paths with identical Widget type names declared in different namespaces, verifying that source generation no longer fails with CS8785.
