### PR TITLE
Expose Cairo routines for reading and creating .png files

### DIFF
--- a/src/Libs/cairo-1.0/Internal/ImageSurface.cs
+++ b/src/Libs/cairo-1.0/Internal/ImageSurface.cs
@@ -11,6 +11,9 @@ public class ImageSurface
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_image_surface_create_for_data")]
     public static extern SurfaceOwnedHandle CreateForData(IntPtr data, Cairo.Format format, int width, int height, int stride);
 
+    [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_image_surface_create_from_png")]
+    public static extern SurfaceOwnedHandle CreateFromPng(GLib.Internal.NonNullableUtf8StringOwnedHandle filename);
+
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_image_surface_get_data")]
     public static extern IntPtr GetData(SurfaceHandle handle);
 

--- a/src/Libs/cairo-1.0/Internal/Surface.cs
+++ b/src/Libs/cairo-1.0/Internal/Surface.cs
@@ -64,4 +64,7 @@ public partial class Surface
 
     [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_surface_status")]
     public static extern Status Status(SurfaceHandle handle);
+
+    [DllImport(CairoImportResolver.Library, EntryPoint = "cairo_surface_write_to_png")]
+    public static extern Status WriteToPng(SurfaceHandle handle, GLib.Internal.NonNullableUtf8StringOwnedHandle filename);
 }

--- a/src/Libs/cairo-1.0/Public/ImageSurface.cs
+++ b/src/Libs/cairo-1.0/Public/ImageSurface.cs
@@ -19,6 +19,12 @@ public class ImageSurface : Surface
         SetUserData(data);
     }
 
+    public ImageSurface(string pngFilename) :
+        base(Internal.ImageSurface.CreateFromPng(GLib.Internal.NonNullableUtf8StringOwnedHandle.Create(pngFilename)))
+    {
+        Handle.AddMemoryPressure(GetSizeInBytes());
+    }
+
     private void SetUserData(GLib.Bytes data)
     {
         var userDataHandler = new Internal.UserDataHandler(data.Handle);

--- a/src/Libs/cairo-1.0/Public/Surface.cs
+++ b/src/Libs/cairo-1.0/Public/Surface.cs
@@ -86,4 +86,10 @@ public partial class Surface
             ? null
             : new Device(deviceHandle.OwnedCopy());
     }
+
+    public Status WriteToPng(string filename)
+    {
+        using var filenameNative = GLib.Internal.NonNullableUtf8StringOwnedHandle.Create(filename);
+        return Internal.Surface.WriteToPng(Handle, filenameNative);
+    }
 }


### PR DESCRIPTION
- [X ] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
- 
This pull request exposes the Cairo_image_surface_create_from_png and cairo_surface_write_to_png routines and thereby resolves #1229.

It replaces the earlier pull request #1553, which had some problems with git squash. 
