### PR TITLE
Generator: Use UntypedRecord model in untyped record renderers

### DIFF
--- a/src/Generation/Generator/Renderer/Internal/ReturnType/Converter/UntypedRecord.cs
+++ b/src/Generation/Generator/Renderer/Internal/ReturnType/Converter/UntypedRecord.cs
@@ -16,8 +16,8 @@ internal class UntypedRecord : ReturnTypeConverter
 
         var typeName = returnType switch
         {
-            { Transfer: Transfer.Full } => Model.TypedRecord.GetFullyQuallifiedOwnedHandle(type),
-            { Transfer: Transfer.None } => Model.TypedRecord.GetFullyQuallifiedUnownedHandle(type),
+            { Transfer: Transfer.Full } => Model.UntypedRecord.GetFullyQuallifiedOwnedHandle(type),
+            { Transfer: Transfer.None } => Model.UntypedRecord.GetFullyQuallifiedUnownedHandle(type),
             _ => throw new Exception($"Unsupported transfer type {returnType.Transfer} for untyped record {type.Name}")
         };
 

--- a/src/Generation/Generator/Renderer/Internal/UntypedRecordData.cs
+++ b/src/Generation/Generator/Renderer/Internal/UntypedRecordData.cs
@@ -21,7 +21,7 @@ namespace {Namespace.GetInternalName(record.Namespace)};
 
 {PlatformSupportAttribute.Render(record as GirModel.PlatformDependent)}
 [StructLayout(LayoutKind.Sequential)]
-public partial struct {Model.TypedRecord.GetDataName(record)}
+public partial struct {Model.UntypedRecord.GetDataName(record)}
 {{
     {record.Fields
         .Select(x => x.AnyTypeOrCallback)

--- a/src/Generation/Generator/Renderer/Internal/UntypedRecordHandle.cs
+++ b/src/Generation/Generator/Renderer/Internal/UntypedRecordHandle.cs
@@ -17,7 +17,7 @@ internal static class UntypedRecordHandle
         var arrayHandleType = Model.UntypedRecord.GetInternalArrayHandle(record);
         var arrayUnownedHandleTypeName = Model.UntypedRecord.GetInternalArrayUnownedHandle(record);
         var arrayOwnedHandleTypeName = Model.UntypedRecord.GetInternalArrayOwnedHandle(record);
-        var fullyQualifiedType = Model.TypedRecord.GetFullyQualifiedPublicClassName(record);
+        var fullyQualifiedType = Model.UntypedRecord.GetFullyQualifiedPublicClassName(record);
         var fullyQuallifiedDataName = Model.UntypedRecord.GetFullyQuallifiedDataName(record);
 
         return $@"using System;
@@ -186,7 +186,7 @@ public class {arrayUnownedHandleTypeName} : {arrayHandleType}
         {{
             var ownedHandle = new {Model.UntypedRecord.GetFullyQuallifiedUnownedHandle(record)}(currentHandle).Copy();
             data[i] = new {fullyQualifiedType}(ownedHandle);
-            currentHandle += Marshal.SizeOf<{Model.TypedRecord.GetFullyQuallifiedDataName(record)}>();
+            currentHandle += Marshal.SizeOf<{Model.UntypedRecord.GetFullyQuallifiedDataName(record)}>();
         }}
 
         return data;

--- a/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/UntypedRecordArray.cs
+++ b/src/Generation/Generator/Renderer/Public/ParameterToNativeExpression/Converter/UntypedRecordArray.cs
@@ -89,10 +89,10 @@ internal class UntypedRecordArray : ToNativeParameterConverter
         parameter.SetCallName(() => nativeVariableName);
 
         var nullable = parameter.Parameter.Nullable
-            ? $"{parameterName} is null ? ({Model.TypedRecord.GetFullyQuallifiedArrayHandle(record)}){Model.TypedRecord.GetFullyQuallifiedArrayNullHandle(record)} : "
+            ? $"{parameterName} is null ? ({Model.UntypedRecord.GetFullyQuallifiedArrayHandle(record)}){Model.UntypedRecord.GetFullyQuallifiedArrayNullHandle(record)} : "
             : string.Empty;
 
-        parameter.SetExpression(() => $"var {nativeVariableName} = {nullable} {Model.TypedRecord.GetFullyQuallifiedArrayOwnedHandle(record)}.Create({parameterName});");
+        parameter.SetExpression(() => $"var {nativeVariableName} = {nullable} {Model.UntypedRecord.GetFullyQuallifiedArrayOwnedHandle(record)}.Create({parameterName});");
 
         var lengthIndex = parameter.Parameter.AnyTypeOrVarArgs.AsT0.AsT1.Length ?? throw new Exception("Length missing");
         var lengthParameter = allParameters.ElementAt(lengthIndex);


### PR DESCRIPTION
The untyped record renderers and converters used the TypedRecord model to look up handle, data and class names. The generated output is identical as both models currently produce the same names, but the naming could diverge one day.

All generated files were checked before and after the change - they remain identical.

Merge #1328 afterwards.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
