### PR TITLE
docs: organize ecosystem projects by platform

### DIFF
--- a/docs/docs/libraries.md
+++ b/docs/docs/libraries.md
@@ -1,21 +1,44 @@
 # Libraries
 
-The following libraries add new functionality to gir.core. To add a new library to the list [edit this page](https://github.com/gircore/gir.core/edit/main/docs/docs/ecosystem.md).
+The following projects integrate with GirCore. They are grouped by the application platform they extend. To add a new library to the list, [edit this page](https://github.com/gircore/gir.core/edit/main/docs/docs/libraries.md).
 
-## Nickvision.Desktop
-A cross platform library made to encapsulate difference between Windows and Linux systems through C# service classes.
+## GTK
 
-[GitHub](https://github.com/nickvisionapps/desktop)
-[Nuget](https://www.nuget.org/packages/Nickvision.Desktop)
+### Nickvision.Desktop
 
-## Nickvision.Desktop.GNOME
-A library containing extensions to gir.core and helpers for working with blueprint files through C# projects.
+A cross-platform library that encapsulates differences between Windows and Linux systems through C# service classes.
 
-[GitHub](https://github.com/nickvisionapps/desktop)
-[Nuget](https://www.nuget.org/packages/Nickvision.Desktop.GNOME)
+- [GitHub](https://github.com/nickvisionapps/desktop)
+- [NuGet](https://www.nuget.org/packages/Nickvision.Desktop)
 
-## Nickvision.FlatpakGenerator
-A tool for generating a `nuget-sources.json` file which can be included into your app's flatpak build.
+### Nickvision.Desktop.GNOME
 
-[GitHub](https://github.com/nickvisionapps/flatpakgenerator)
-[Nuget](https://www.nuget.org/packages/Nickvision.FlatpakGenerator)
+A library containing GirCore extensions and helpers for using Blueprint files in C# projects.
+
+- [GitHub](https://github.com/nickvisionapps/desktop)
+- [NuGet](https://www.nuget.org/packages/Nickvision.Desktop.GNOME)
+
+### SkiaSharp.Views.GirCore
+
+A library that provides GTK4 and Cairo-backed views for using SkiaSharp on Linux with GirCore.
+
+- [GitHub](https://github.com/lytico/GirCoreApps/tree/main/src/SkiaSharp.Views.GirCore)
+- [NuGet](https://www.nuget.org/packages/SkiaSharp.Views.GirCore)
+
+## .NET MAUI
+
+### Linux GTK4 backend
+
+The experimental Linux GTK4 backend for .NET MAUI uses GirCore bindings to render MAUI controls as native GTK4 widgets.
+
+- [GitHub](https://github.com/dotnet/maui-labs/tree/main/platforms/Linux.Gtk4)
+- [Documentation](https://learn.microsoft.com/dotnet/maui/developer-tools/platform-backends/linux-gtk4)
+
+## Tooling
+
+### Nickvision.FlatpakGenerator
+
+A tool for generating a `nuget-sources.json` file that can be included in an application's Flatpak build.
+
+- [GitHub](https://github.com/nickvisionapps/flatpakgenerator)
+- [NuGet](https://www.nuget.org/packages/Nickvision.FlatpakGenerator)

--- a/docs/docs/libraries.md
+++ b/docs/docs/libraries.md
@@ -22,8 +22,8 @@ A library containing GirCore extensions and helpers for using Blueprint files in
 
 A library that provides GTK4 and Cairo-backed views for using SkiaSharp on Linux with GirCore.
 
-- [GitHub](https://github.com/lytico/GirCoreApps/tree/main/src/SkiaSharp.Views.GirCore)
-- [NuGet](https://www.nuget.org/packages/SkiaSharp.Views.GirCore)
+- [GitHub](https://github.com/mono/SkiaSharp/tree/main/source/SkiaSharp.Views/SkiaSharp.Views.Gtk4)
+- [NuGet](https://www.nuget.org/packages/SkiaSharp.Views.Gtk4/)
 
 ## .NET MAUI
 
@@ -33,6 +33,7 @@ The experimental Linux GTK4 backend for .NET MAUI uses GirCore bindings to rende
 
 - [GitHub](https://github.com/dotnet/maui-labs/tree/main/platforms/Linux.Gtk4)
 - [Documentation](https://learn.microsoft.com/dotnet/maui/developer-tools/platform-backends/linux-gtk4)
+- [NuGet](https://www.nuget.org/packages/Microsoft.Maui.Platforms.Linux.Gtk4/)
 
 ## Tooling
 


### PR DESCRIPTION
## Summary

- I grouped the ecosystem libraries by application platform so GTK and .NET MAUI integrations are easier to discover.
- I added the GirCore-backed SkiaSharp views and the experimental .NET MAUI Linux GTK4 backend, with links to their code, packages, and documentation.
- I separated FlatpakGenerator into a tooling section and corrected the stale “edit this page” link.

## Validation

- `git diff --check origin/main...HEAD`
- Targeted Markdown heading/link validation against the exact commit
- Verified all 10 unique external links return HTTP 2xx

A full DocFX build was not run because a .NET SDK is not available in this environment; this is a documentation-only change.

Fixes #1568
Fixes #1569
Fixes #1570

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
