### PR TITLE
Load element types of container types and arrays

### DIFF
--- a/src/Generation/GirLoader/Input/Type.cs
+++ b/src/Generation/GirLoader/Input/Type.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace GirLoader.Input;
@@ -9,4 +10,12 @@ public class Type
 
     [XmlAttribute("type", Namespace = "http://www.gtk.org/introspection/c/1.0")]
     public string? CType { get; set; }
+
+    //Container types like GLib.List carry their element type as nested type or
+    //array elements ("AnyType*" in the GIR schema). GLib.HashTable carries two:
+    //the key and the value type. The document order is preserved as it
+    //distinguishes the key from the value type.
+    [XmlElement("type", typeof(Type))]
+    [XmlElement("array", typeof(ArrayType))]
+    public List<object> AnyTypes { get; set; } = new();
 }

--- a/src/Generation/GirLoader/Output/ArrayTypeReference.GirModel.cs
+++ b/src/Generation/GirLoader/Output/ArrayTypeReference.GirModel.cs
@@ -5,12 +5,8 @@ public partial class ArrayTypeReference : GirModel.ArrayType
     int? GirModel.ArrayType.Length => Length;
     bool GirModel.ArrayType.IsZeroTerminated => IsZeroTerminated;
     int? GirModel.ArrayType.FixedSize => FixedSize;
-    bool GirModel.ArrayType.IsPointer => TypeReference.CTypeReference?.IsPointer ?? false;
-    bool GirModel.ArrayType.IsConst => TypeReference.CTypeReference?.IsConst ?? false;
-    bool GirModel.ArrayType.IsVolatile => TypeReference.CTypeReference?.IsVolatile ?? false;
-    GirModel.AnyType GirModel.ArrayType.AnyType => TypeReference switch
-    {
-        ArrayTypeReference arrayTypeReference => GirModel.AnyType.From(arrayTypeReference),
-        _ => GirModel.AnyType.From(TypeReference.GetResolvedType())
-    };
+    bool GirModel.ArrayType.IsPointer => ElementTypeReference.CTypeReference?.IsPointer ?? false;
+    bool GirModel.ArrayType.IsConst => ElementTypeReference.CTypeReference?.IsConst ?? false;
+    bool GirModel.ArrayType.IsVolatile => ElementTypeReference.CTypeReference?.IsVolatile ?? false;
+    GirModel.AnyType GirModel.ArrayType.AnyType => ElementTypeReference.GetResolvedAnyType();
 }

--- a/src/Generation/GirLoader/Output/ArrayTypeReference.cs
+++ b/src/Generation/GirLoader/Output/ArrayTypeReference.cs
@@ -5,12 +5,17 @@ public partial class ArrayTypeReference : TypeReference
     public int? Length { get; init; }
     public bool IsZeroTerminated { get; init; }
     public int? FixedSize { get; init; }
-    public TypeReference TypeReference { get; }
 
-    public override Type? Type => TypeReference.Type;
+    //An array carries exactly one element type ("AnyType" in the GIR schema)
+    public TypeReference ElementTypeReference => ElementTypeReferences[0];
 
-    public ArrayTypeReference(TypeReference typeReference, SymbolNameReference? symbolNameReference, CTypeReference? ctype) : base(symbolNameReference, ctype)
+    public override Type? Type => ElementTypeReference.Type;
+
+    public ArrayTypeReference(TypeReference elementTypeReference, SymbolNameReference? symbolNameReference, CTypeReference? ctype)
+        : base(symbolNameReference, ctype, new[] { elementTypeReference })
     {
-        TypeReference = typeReference;
     }
+
+    internal override GirModel.AnyType GetResolvedAnyType()
+        => GirModel.AnyType.From(this);
 }

--- a/src/Generation/GirLoader/Output/ByteArrayTypeReference.cs
+++ b/src/Generation/GirLoader/Output/ByteArrayTypeReference.cs
@@ -3,7 +3,7 @@ namespace GirLoader.Output;
 public class ByteArrayTypeReference : ArrayTypeReference, GirModel.ByteArrayType
 {
     public ByteArrayTypeReference(ArrayTypeReference arrayTypeReference) : base(
-        typeReference: arrayTypeReference.TypeReference,
+        elementTypeReference: arrayTypeReference.ElementTypeReference,
         symbolNameReference: arrayTypeReference.SymbolNameReference,
         ctype: arrayTypeReference.CTypeReference)
     {

--- a/src/Generation/GirLoader/Output/Field.GirModel.cs
+++ b/src/Generation/GirLoader/Output/Field.GirModel.cs
@@ -18,11 +18,9 @@ public partial class Field : GirModel.Field
             if (Callback is not null)
                 return Callback;
 
-            return TypeReference switch
-            {
-                ArrayTypeReference arrayTypeReference => GirModel.AnyType.From(arrayTypeReference),
-                _ => GirModel.AnyType.From(TypeReference.GetResolvedType())
-            };
+            return TypeReference.GetResolvedAnyType();
         }
     }
+
+    System.Collections.Generic.IReadOnlyList<GirModel.AnyType> GirModel.ElementTypeContainer.ElementTypes => TypeReference.GetResolvedElementTypes();
 }

--- a/src/Generation/GirLoader/Output/GArrayTypeReference.cs
+++ b/src/Generation/GirLoader/Output/GArrayTypeReference.cs
@@ -3,7 +3,7 @@ namespace GirLoader.Output;
 public class GArrayTypeReference : ArrayTypeReference, GirModel.GArrayType
 {
     public GArrayTypeReference(ArrayTypeReference arrayTypeReference) : base(
-            typeReference: arrayTypeReference.TypeReference,
+            elementTypeReference: arrayTypeReference.ElementTypeReference,
             symbolNameReference: arrayTypeReference.SymbolNameReference,
             ctype: arrayTypeReference.CTypeReference)
     {

--- a/src/Generation/GirLoader/Output/PointerArrayTypeReference.cs
+++ b/src/Generation/GirLoader/Output/PointerArrayTypeReference.cs
@@ -3,7 +3,7 @@ namespace GirLoader.Output;
 public class PointerArrayTypeReference : ArrayTypeReference, GirModel.PointerArrayType
 {
     public PointerArrayTypeReference(ArrayTypeReference arrayTypeReference) : base(
-        typeReference: arrayTypeReference.TypeReference,
+        elementTypeReference: arrayTypeReference.ElementTypeReference,
         symbolNameReference: arrayTypeReference.SymbolNameReference,
         ctype: arrayTypeReference.CTypeReference)
     {

--- a/src/Generation/GirLoader/Output/Property.GirModel.cs
+++ b/src/Generation/GirLoader/Output/Property.GirModel.cs
@@ -3,11 +3,7 @@ namespace GirLoader.Output;
 public partial class Property : GirModel.Property
 {
     string GirModel.Property.Name => Name;
-    GirModel.AnyType GirModel.Property.AnyType => TypeReference switch
-    {
-        ArrayTypeReference arrayTypeReference => GirModel.AnyType.From(arrayTypeReference),
-        _ => GirModel.AnyType.From(TypeReference.GetResolvedType())
-    };
+    GirModel.AnyType GirModel.Property.AnyType => TypeReference.GetResolvedAnyType();
     bool GirModel.Property.Readable => Readable;
     bool GirModel.Property.Writeable => Writeable;
     bool GirModel.Property.ConstructOnly => ConstructOnly;

--- a/src/Generation/GirLoader/Output/ResolveableTypeReference.cs
+++ b/src/Generation/GirLoader/Output/ResolveableTypeReference.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace GirLoader.Output;
 
 public class ResolveableTypeReference : TypeReference
@@ -5,8 +7,8 @@ public class ResolveableTypeReference : TypeReference
     private Type? _resolvedType;
     public override Type? Type => _resolvedType;
 
-    public ResolveableTypeReference(SymbolNameReference? symbolNameReference, CTypeReference? ctype)
-        : base(symbolNameReference, ctype)
+    public ResolveableTypeReference(SymbolNameReference? symbolNameReference, CTypeReference? ctype, IReadOnlyList<TypeReference>? elementTypeReferences = null)
+        : base(symbolNameReference, ctype, elementTypeReferences)
     {
     }
 
@@ -14,4 +16,7 @@ public class ResolveableTypeReference : TypeReference
     {
         _resolvedType = type;
     }
+
+    internal override GirModel.AnyType GetResolvedAnyType()
+        => GirModel.AnyType.From(GetResolvedType());
 }

--- a/src/Generation/GirLoader/Output/ReturnValue.GirModel.cs
+++ b/src/Generation/GirLoader/Output/ReturnValue.GirModel.cs
@@ -1,12 +1,12 @@
+using System.Collections.Generic;
+
 namespace GirLoader.Output;
 
 public partial class ReturnValue : GirModel.ReturnType
 {
-    GirModel.AnyType GirModel.ReturnType.AnyType => TypeReference switch
-    {
-        ArrayTypeReference arrayTypeReference => GirModel.AnyType.From(arrayTypeReference),
-        _ => GirModel.AnyType.From(TypeReference.GetResolvedType())
-    };
+    GirModel.AnyType GirModel.ReturnType.AnyType => TypeReference.GetResolvedAnyType();
+
+    IReadOnlyList<GirModel.AnyType> GirModel.ElementTypeContainer.ElementTypes => TypeReference.GetResolvedElementTypes();
 
     GirModel.Transfer GirModel.ReturnType.Transfer => Transfer.ToGirModel();
 

--- a/src/Generation/GirLoader/Output/SingleParameter.GirModel.cs
+++ b/src/Generation/GirLoader/Output/SingleParameter.GirModel.cs
@@ -19,12 +19,13 @@ public partial class SingleParameter : GirModel.Parameter
     );
 
     OneOf.OneOf<GirModel.AnyType, GirModel.VarArgs> GirModel.Parameter.AnyTypeOrVarArgs => TypeReferenceOrVarArgs.Match<OneOf.OneOf<GirModel.AnyType, GirModel.VarArgs>>(
-        typeReference => typeReference switch
-        {
-            ArrayTypeReference arrayTypeReference => GirModel.AnyType.From(arrayTypeReference),
-            _ => GirModel.AnyType.From(typeReference.GetResolvedType())
-        },
+        typeReference => typeReference.GetResolvedAnyType(),
         varargs => varargs
+    );
+
+    System.Collections.Generic.IReadOnlyList<GirModel.AnyType> GirModel.ElementTypeContainer.ElementTypes => TypeReferenceOrVarArgs.Match(
+        typeReference => typeReference.GetResolvedElementTypes(),
+        varargs => System.Array.Empty<GirModel.AnyType>()
     );
     GirModel.Direction GirModel.Parameter.Direction => Direction.ToGirModel();
     GirModel.Transfer GirModel.Parameter.Transfer => Transfer.ToGirModel();

--- a/src/Generation/GirLoader/Output/StandardArrayTypeReference.cs
+++ b/src/Generation/GirLoader/Output/StandardArrayTypeReference.cs
@@ -3,7 +3,7 @@ namespace GirLoader.Output;
 public class StandardArrayTypeReference : ArrayTypeReference, GirModel.StandardArrayType
 {
     public StandardArrayTypeReference(ArrayTypeReference arrayTypeReference) : base(
-        typeReference: arrayTypeReference.TypeReference,
+        elementTypeReference: arrayTypeReference.ElementTypeReference,
         symbolNameReference: arrayTypeReference.SymbolNameReference,
         ctype: arrayTypeReference.CTypeReference)
     {

--- a/src/Generation/GirLoader/Output/TypeReference.cs
+++ b/src/Generation/GirLoader/Output/TypeReference.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace GirLoader.Output;
 
@@ -9,12 +11,21 @@ public abstract class TypeReference
     public SymbolNameReference? SymbolNameReference { get; }
     public abstract Type? Type { get; }
 
+    /// <summary>
+    /// Element type references of this type reference: container types like
+    /// GLib.List carry their element type here, GLib.HashTable carries two
+    /// (the key and the value type) and arrays carry exactly one. Empty if
+    /// there are no element types.
+    /// </summary>
+    public IReadOnlyList<TypeReference> ElementTypeReferences { get; }
+
     #endregion
 
-    protected TypeReference(SymbolNameReference? symbolNameReference, CTypeReference? ctypeReference)
+    protected TypeReference(SymbolNameReference? symbolNameReference, CTypeReference? ctypeReference, IReadOnlyList<TypeReference>? elementTypeReferences = null)
     {
         CTypeReference = ctypeReference;
         SymbolNameReference = symbolNameReference;
+        ElementTypeReferences = elementTypeReferences ?? Array.Empty<TypeReference>();
     }
 
     public Type GetResolvedType()
@@ -27,11 +38,15 @@ public abstract class TypeReference
         throw new InvalidOperationException($"The type {ctypeName} / {symbolName} has not been resolved.");
     }
 
+    internal abstract GirModel.AnyType GetResolvedAnyType();
+
+    internal IReadOnlyList<GirModel.AnyType> GetResolvedElementTypes()
+        => ElementTypeReferences
+            .Select(x => x.GetResolvedAnyType())
+            .ToArray();
+
     public override string ToString()
     {
         return $"{nameof(TypeReference)}: {nameof(CTypeReference)}: {CTypeReference}, {nameof(SymbolNameReference)}: {SymbolNameReference}";
     }
-
-    internal bool GetIsResolved()
-        => Type is { };
 }

--- a/src/Generation/GirLoader/Output/TypeReferenceFactory.cs
+++ b/src/Generation/GirLoader/Output/TypeReferenceFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace GirLoader.Output;
 
@@ -33,11 +34,27 @@ internal class TypeReferenceFactory
             return false;
         }
 
-        typeReference = new ResolveableTypeReference(
-            symbolNameReference: GetSymbolNameReference(anyType.Type.Name),
-            ctype: GetCType(anyType.Type.CType));
+        typeReference = Create(anyType.Type);
 
         return true;
+    }
+
+    private ResolveableTypeReference Create(Input.Type type)
+    {
+        return new ResolveableTypeReference(
+            symbolNameReference: GetSymbolNameReference(type.Name),
+            ctype: GetCType(type.CType),
+            elementTypeReferences: type.AnyTypes.Select(Create).ToArray());
+    }
+
+    private TypeReference Create(object typeOrArray)
+    {
+        return typeOrArray switch
+        {
+            Input.Type type => Create(type),
+            Input.ArrayType arrayType => Create(arrayType),
+            _ => throw new Exception($"Unknown element type {typeOrArray.GetType().Name}")
+        };
     }
 
     private bool TryCreateArrayTypeReference(Input.AnyType anyType, [NotNullWhen(true)] out ArrayTypeReference? arrayTypeReference)
@@ -48,32 +65,37 @@ internal class TypeReferenceFactory
             return false;
         }
 
-        var typeReference = Create(anyType.Array);
+        arrayTypeReference = Create(anyType.Array);
 
-        int? length = int.TryParse(anyType.Array.Length, out var l) ? l : null;
-        int? fixedSize = int.TryParse(anyType.Array.FixedSize, out var f) ? f : null;
+        return true;
+    }
+
+    private ArrayTypeReference Create(Input.ArrayType arrayType)
+    {
+        var elementTypeReference = Create((Input.AnyType) arrayType);
+
+        int? length = int.TryParse(arrayType.Length, out var l) ? l : null;
+        int? fixedSize = int.TryParse(arrayType.FixedSize, out var f) ? f : null;
 
         var reference = new ArrayTypeReference(
-            typeReference: typeReference,
+            elementTypeReference: elementTypeReference,
             symbolNameReference: null,
-            ctype: GetCType(anyType.Array.CType))
+            ctype: GetCType(arrayType.CType))
         {
             Length = length,
             FixedSize = fixedSize,
             //The fallback is required as gobject-introspection expects an array to be zero terminated,
             //if neither length nor fixedSize are given.
-            IsZeroTerminated = anyType.Array.ZeroTerminated || (length is null && fixedSize is null)
+            IsZeroTerminated = arrayType.ZeroTerminated || (length is null && fixedSize is null)
         };
 
-        arrayTypeReference = anyType.Array.Name switch
+        return arrayType.Name switch
         {
             "GLib.Array" => new GArrayTypeReference(reference),
             "GLib.ByteArray" => new ByteArrayTypeReference(reference),
             "GLib.PtrArray" => new PointerArrayTypeReference(reference),
             _ => new StandardArrayTypeReference(reference)
         };
-
-        return true;
     }
 
     public IEnumerable<TypeReference> Create(IEnumerable<Input.Implement> implements)

--- a/src/Generation/GirLoader/ReferenceResolvers/TypeReferences/RepositoryTypeReferenceResolver.cs
+++ b/src/Generation/GirLoader/ReferenceResolvers/TypeReferences/RepositoryTypeReferenceResolver.cs
@@ -33,21 +33,21 @@ internal class RepositoryTypeReferenceResolver
 
     public void ResolveTypeReference(Output.TypeReference reference, Output.Repository repository)
     {
-        if (reference is Output.ArrayTypeReference arrayTypeReference)
-        {
-            // Array type references are not resolved directly. Only their type get's resolved
-            // because arrays are no type themself. They only provide structure.
-            ResolveTypeReference(arrayTypeReference.TypeReference, repository);
-        }
-        else if (reference is Output.ResolveableTypeReference resolveableTypeReference)
+        foreach (var elementTypeReference in reference.ElementTypeReferences)
+            ResolveTypeReference(elementTypeReference, repository);
+
+        if (reference is Output.ResolveableTypeReference resolveableTypeReference)
         {
             if (_typeReferenceResolver.Resolve(resolveableTypeReference, repository, out var type))
                 resolveableTypeReference.ResolveAs(type);
             else
                 Log.Verbose($"Could not resolve type reference {reference}");
         }
-        else
+        else if (reference is not Output.ArrayTypeReference)
         {
+            // Array type references are not resolved directly. Only their element type
+            // gets resolved above because arrays are no type themself. They only provide
+            // structure.
             throw new Exception($"Unknown {nameof(Output.TypeReference)} {reference.GetType().Name}");
         }
     }

--- a/src/Generation/GirModel/ElementTypeContainer.cs
+++ b/src/Generation/GirModel/ElementTypeContainer.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace GirModel;
+
+public interface ElementTypeContainer
+{
+    /// <summary>
+    /// The element types of the type: container types like GLib.List carry
+    /// their element type here, GLib.HashTable carries two (the key and the
+    /// value type) and arrays carry exactly one. Empty if the type has no
+    /// element types.
+    /// </summary>
+    IReadOnlyList<AnyType> ElementTypes { get; }
+}

--- a/src/Generation/GirModel/Field.cs
+++ b/src/Generation/GirModel/Field.cs
@@ -2,7 +2,7 @@ using OneOf;
 
 namespace GirModel;
 
-public interface Field
+public interface Field : ElementTypeContainer
 {
     string Name { get; }
     bool IsReadable { get; }

--- a/src/Generation/GirModel/Parameter.cs
+++ b/src/Generation/GirModel/Parameter.cs
@@ -1,6 +1,6 @@
 namespace GirModel;
 
-public interface Parameter : Nullable
+public interface Parameter : Nullable, ElementTypeContainer
 {
     string Name { get; }
     Direction Direction { get; }

--- a/src/Generation/GirModel/ReturnType.cs
+++ b/src/Generation/GirModel/ReturnType.cs
@@ -1,6 +1,6 @@
 namespace GirModel;
 
-public interface ReturnType : Nullable
+public interface ReturnType : Nullable, ElementTypeContainer
 {
     AnyType AnyType { get; }
     Transfer Transfer { get; }

--- a/src/Tests/Generation/GirLoader.Tests/ElementTypeTest.cs
+++ b/src/Tests/Generation/GirLoader.Tests/ElementTypeTest.cs
@@ -1,0 +1,203 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GirLoader.Test;
+
+[TestClass, TestCategory("UnitTest")]
+public class ElementTypeTest
+{
+    private static Output.Repository LoadRepository(string namespaceContentXml)
+    {
+        var xml = $"""
+                   <?xml version="1.0"?>
+                   <repository xmlns="http://www.gtk.org/introspection/core/1.0"
+                               xmlns:c="http://www.gtk.org/introspection/c/1.0"
+                               xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+                     <namespace name="Test" version="1.0">
+                       <record name="TestRecord" c:type="TestRecord">
+                       </record>
+                       {namespaceContentXml}
+                     </namespace>
+                   </repository>
+                   """;
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var inputRepository = stream.DeserializeGirInputModel();
+
+        return new Loader(DummyResolver.Resolve).Load(new[] { inputRepository }).First();
+    }
+
+    [TestMethod]
+    public void ElementTypeOfListReturnValueShouldBeLoaded()
+    {
+        var repository = LoadRepository("""
+                                        <function name="get_list" c:identifier="test_get_list">
+                                          <return-value transfer-ownership="full">
+                                            <type name="GLib.List" c:type="GList*">
+                                              <type name="TestRecord"/>
+                                            </type>
+                                          </return-value>
+                                        </function>
+                                        """);
+
+        var returnValue = repository.Namespace.Functions.First().ReturnValue;
+
+        var typeReference = (Output.ResolveableTypeReference) returnValue.TypeReference;
+        typeReference.ElementTypeReferences.Should().HaveCount(1);
+        typeReference.ElementTypeReferences[0].Type.Should().BeOfType<Output.Record>();
+
+        GirModel.ReturnType returnType = returnValue;
+        var elementType = returnType.ElementTypes.Should().ContainSingle().Which;
+        elementType.Is<GirModel.Record>(out var record).Should().BeTrue();
+        record!.Name.Should().Be("TestRecord");
+    }
+
+    [TestMethod]
+    public void KeyAndValueElementTypesOfHashTableReturnValueShouldBeLoadedInDocumentOrder()
+    {
+        var repository = LoadRepository("""
+                                        <function name="get_hash_table" c:identifier="test_get_hash_table">
+                                          <return-value transfer-ownership="full">
+                                            <type name="GLib.HashTable" c:type="GHashTable*">
+                                              <type name="utf8"/>
+                                              <type name="TestRecord"/>
+                                            </type>
+                                          </return-value>
+                                        </function>
+                                        """);
+
+        GirModel.ReturnType returnType = repository.Namespace.Functions.First().ReturnValue;
+
+        returnType.ElementTypes.Should().HaveCount(2);
+        returnType.ElementTypes[0].Is<GirModel.String>().Should().BeTrue();
+        returnType.ElementTypes[1].Is<GirModel.Record>().Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void ElementTypeOfListParameterShouldBeLoaded()
+    {
+        var repository = LoadRepository("""
+                                        <function name="take_list" c:identifier="test_take_list">
+                                          <return-value transfer-ownership="none">
+                                            <type name="none" c:type="void"/>
+                                          </return-value>
+                                          <parameters>
+                                            <parameter name="list" transfer-ownership="full">
+                                              <type name="GLib.SList" c:type="GSList*">
+                                                <type name="TestRecord"/>
+                                              </type>
+                                            </parameter>
+                                          </parameters>
+                                        </function>
+                                        """);
+
+        GirModel.Parameter parameter = repository.Namespace.Functions.First().ParameterList.SingleParameters.First();
+
+        var elementType = parameter.ElementTypes.Should().ContainSingle().Which;
+        elementType.Is<GirModel.Record>(out var record).Should().BeTrue();
+        record!.Name.Should().Be("TestRecord");
+    }
+
+    [TestMethod]
+    public void ElementTypeOfListFieldShouldBeLoaded()
+    {
+        var repository = LoadRepository("""
+                                        <record name="FieldRecord" c:type="FieldRecord">
+                                          <field name="data">
+                                            <type name="GLib.SList" c:type="GSList*">
+                                              <type name="TestRecord"/>
+                                            </type>
+                                          </field>
+                                        </record>
+                                        """);
+
+        GirModel.Field field = repository.Namespace.Records
+            .First(x => x.Name == "FieldRecord")
+            .Fields.First();
+
+        var elementType = field.ElementTypes.Should().ContainSingle().Which;
+        elementType.Is<GirModel.Record>(out var record).Should().BeTrue();
+        record!.Name.Should().Be("TestRecord");
+    }
+
+    [TestMethod]
+    public void ReturnValueWithoutElementTypeShouldHaveNoElementTypes()
+    {
+        var repository = LoadRepository("""
+                                        <function name="get_int" c:identifier="test_get_int">
+                                          <return-value transfer-ownership="none">
+                                            <type name="gint" c:type="int"/>
+                                          </return-value>
+                                        </function>
+                                        """);
+
+        GirModel.ReturnType returnType = repository.Namespace.Functions.First().ReturnValue;
+
+        returnType.ElementTypes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ArrayElementTypeOfListReturnValueShouldBeLoaded()
+    {
+        //Occurs in the wild: g_dtls_client_connection_get_accepted_cas returns
+        //a GLib.List of GLib.ByteArray elements.
+        var repository = LoadRepository("""
+                                        <function name="get_list_of_byte_arrays" c:identifier="test_get_list_of_byte_arrays">
+                                          <return-value transfer-ownership="full">
+                                            <type name="GLib.List" c:type="GList*">
+                                              <array name="GLib.ByteArray">
+                                                <type name="guint8" c:type="guint8"/>
+                                              </array>
+                                            </type>
+                                          </return-value>
+                                        </function>
+                                        """);
+
+        GirModel.ReturnType returnType = repository.Namespace.Functions.First().ReturnValue;
+
+        var elementType = returnType.ElementTypes.Should().ContainSingle().Which;
+        elementType.IsGLibByteArray().Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void ElementTypeOfArrayReturnValueShouldBeLoaded()
+    {
+        var repository = LoadRepository("""
+                                        <function name="get_strings" c:identifier="test_get_strings">
+                                          <return-value transfer-ownership="full">
+                                            <array c:type="char**">
+                                              <type name="utf8" c:type="char*"/>
+                                            </array>
+                                          </return-value>
+                                        </function>
+                                        """);
+
+        GirModel.ReturnType returnType = repository.Namespace.Functions.First().ReturnValue;
+
+        var elementType = returnType.ElementTypes.Should().ContainSingle().Which;
+        elementType.Is<GirModel.String>().Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void UnresolvableElementTypeShouldThrow()
+    {
+        var repository = LoadRepository("""
+                                        <function name="get_list" c:identifier="test_get_list">
+                                          <return-value transfer-ownership="full">
+                                            <type name="GLib.List" c:type="GList*">
+                                              <type name="Unknown.Thing"/>
+                                            </type>
+                                          </return-value>
+                                        </function>
+                                        """);
+
+        GirModel.ReturnType returnType = repository.Namespace.Functions.First().ReturnValue;
+
+        var act = () => returnType.ElementTypes;
+        act.Should().Throw<InvalidOperationException>();
+    }
+}


### PR DESCRIPTION
This is the first PR of the split of #1573, as discussed in the review there: it contains only the `GirModel` and `GirLoader` layers, so the low-level data is prepared to be consumed by higher levels later. #1573 stays a draft and serves as a reference for where this is heading (GLib.List/SList element copy/free support in the generator).

## High-level summary
GirCore generates C# bindings from XML files that describe C libraries. When a C function returns a list, that XML also says what's inside the list (e.g. "a list of Pixbuf objects") — but until now, the code that parses the XML simply ignored that part, so the rest of the tool never knew the element type.

This PR makes the parser read and store that "what's inside" information — for lists, hash tables (key + value type), and arrays — and makes it available to the code-generation layers. Nothing uses it yet: the generated bindings are unchanged. It's the foundation so a follow-up PR can generate proper typed code for list-returning functions (e.g. a real Pixbuf[] instead of an opaque list pointer, with correct memory management).

## What this does

Container types carry their element types as nested children in the gir XML (`AnyType*` in the [RNC schema](https://gitlab.gnome.org/GNOME/gobject-introspection/-/blob/main/docs/gir-1.2.rnc) — zero or more `<type>` **or `<array>`** elements):

```xml
<type name="GLib.List" c:type="GList*">
  <type name="GdkPixbufFormat" c:type="GdkPixbufFormat*"/>
</type>
```

The loader now reads these children (both `<type>` and `<array>` — `Gio-2.0.gir` really contains a `GLib.List` of `GLib.ByteArray` in `g_dtls_client_connection_get_accepted_cas`), preserves their document order (a `GLib.HashTable` distinguishes key and value type by order), resolves them and exposes them through a new interface:

```csharp
public interface ElementTypeContainer
{
    IReadOnlyList<AnyType> ElementTypes { get; }
}
```

`GirModel.ReturnType`, `GirModel.Parameter` and `GirModel.Field` inherit it, following the `GirModel.Nullable` pattern. No renderer consumes the data yet — the generated bindings are **byte-identical** to main (verified by regenerating all libs with both generators and hashing all 15,495 `*.Generated.cs` files).

## Design decisions (mapped to the #1573 review)

- **Element types live on the `TypeReference` base class, not only on `ResolveableTypeReference`.** While addressing the LSP concern from the review I noticed the deeper inconsistency: an array *has* exactly one element type, but modeled it as a "misused" inner `TypeReference` property, so array-typed return values would have reported no element types. Now both reference kinds carry element types uniformly — a container `<type>` has 0..n, an `<array>` exactly 1 (matching the RNC, where both carry `AnyType` children). The data is base-class data, so `GetResolvedElementTypes()` on the base no longer depends on subclass knowledge. `ArrayTypeReference.TypeReference` was renamed to `ElementTypeReference` and is now just an accessor for `ElementTypeReferences[0]`.
- **No subclass switches:** a new polymorphic `GetResolvedAnyType()` replaces the repeated `switch { ArrayTypeReference => ..., _ => ... }` idiom in the `*.GirModel.cs` partials, and the array special-case in `RepositoryTypeReferenceResolver` collapses into uniform recursion over `ElementTypeReferences`.
- **Unresolvable element types throw** (via `GetResolvedType()`) instead of being filtered — no API is better than a broken API. The dead `GetIsResolved()` is removed.
- **No library knowledge in `GirModel`:** no `IsGLibList` or similar — that belongs to a future generator-level PR.

## Open question

Should `ArrayTypeReference : TypeReference` inheritance be dropped entirely (e.g. `OneOf<TypeReference, ArrayTypeReference>` at the use sites)? `ArrayTypeReference.Type` still returns its *element's* type, which keeps `GetResolvedType()` working generically but remains conceptually odd. I left that as-is to keep this PR small — happy to tackle it in a follow-up if you think it's worth it.

## Tests

`ElementTypeTest` covers: list return value, HashTable key/value order, list parameter, list field, no-element-types case, list-of-ByteArray (the real Gio case), array return value (element exposed via `ElementTypes`), and unresolvable element type → throws.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
