### PR TITLE
GirModel: Align GLib array type names to actual GLib names.

### DIFF
--- a/src/Generation/GirLoader/Output/GLib.ArrayTypeReference.cs
+++ b/src/Generation/GirLoader/Output/GLib.ArrayTypeReference.cs
@@ -1,8 +1,8 @@
 namespace GirLoader.Output;
 
-public class GArrayTypeReference : ArrayTypeReference, GirModel.GArrayType
+public class GLibArrayTypeReference : ArrayTypeReference, GirModel.GLibArrayType
 {
-    public GArrayTypeReference(ArrayTypeReference arrayTypeReference) : base(
+    public GLibArrayTypeReference(ArrayTypeReference arrayTypeReference) : base(
             typeReference: arrayTypeReference.TypeReference,
             symbolNameReference: arrayTypeReference.SymbolNameReference,
             ctype: arrayTypeReference.CTypeReference)

--- a/src/Generation/GirLoader/Output/GLib.ByteArrayTypeReference.cs
+++ b/src/Generation/GirLoader/Output/GLib.ByteArrayTypeReference.cs
@@ -1,8 +1,8 @@
 namespace GirLoader.Output;
 
-public class PointerArrayTypeReference : ArrayTypeReference, GirModel.PointerArrayType
+public class GLibByteArrayTypeReference : ArrayTypeReference, GirModel.GLibByteArrayType
 {
-    public PointerArrayTypeReference(ArrayTypeReference arrayTypeReference) : base(
+    public GLibByteArrayTypeReference(ArrayTypeReference arrayTypeReference) : base(
         typeReference: arrayTypeReference.TypeReference,
         symbolNameReference: arrayTypeReference.SymbolNameReference,
         ctype: arrayTypeReference.CTypeReference)

--- a/src/Generation/GirLoader/Output/GLib.PtrArrayTypeReference.cs
+++ b/src/Generation/GirLoader/Output/GLib.PtrArrayTypeReference.cs
@@ -1,8 +1,8 @@
 namespace GirLoader.Output;
 
-public class ByteArrayTypeReference : ArrayTypeReference, GirModel.ByteArrayType
+public class GLibPtrArrayTypeReference : ArrayTypeReference, GirModel.GLibPtrArrayType
 {
-    public ByteArrayTypeReference(ArrayTypeReference arrayTypeReference) : base(
+    public GLibPtrArrayTypeReference(ArrayTypeReference arrayTypeReference) : base(
         typeReference: arrayTypeReference.TypeReference,
         symbolNameReference: arrayTypeReference.SymbolNameReference,
         ctype: arrayTypeReference.CTypeReference)

--- a/src/Generation/GirLoader/Output/TypeReferenceFactory.cs
+++ b/src/Generation/GirLoader/Output/TypeReferenceFactory.cs
@@ -67,9 +67,9 @@ internal class TypeReferenceFactory
 
         arrayTypeReference = anyType.Array.Name switch
         {
-            "GLib.Array" => new GArrayTypeReference(reference),
-            "GLib.ByteArray" => new ByteArrayTypeReference(reference),
-            "GLib.PtrArray" => new PointerArrayTypeReference(reference),
+            "GLib.Array" => new GLibArrayTypeReference(reference),
+            "GLib.ByteArray" => new GLibByteArrayTypeReference(reference),
+            "GLib.PtrArray" => new GLibPtrArrayTypeReference(reference),
             _ => new StandardArrayTypeReference(reference)
         };
 

--- a/src/Generation/GirModel/AnyType.cs
+++ b/src/Generation/GirModel/AnyType.cs
@@ -32,15 +32,15 @@ public static class AnyTypeExtension
 
     public static bool IsGLibPtrArray(this GirModel.AnyType anyType)
         => anyType.TryPickT1(out var arrayType, out _)
-           && arrayType is GirModel.PointerArrayType;
+           && arrayType is GirModel.GLibPtrArrayType;
 
     public static bool IsGLibByteArray(this GirModel.AnyType anyType)
         => anyType.TryPickT1(out var arrayType, out _)
-           && arrayType is GirModel.ByteArrayType;
+           && arrayType is GirModel.GLibByteArrayType;
 
     public static bool IsGLibArray<T>(this GirModel.AnyType anyType) where T : GirModel.Type
         => anyType.TryPickT1(out var arrayType, out _)
-           && arrayType is GirModel.GArrayType
+           && arrayType is GirModel.GLibArrayType
            && arrayType.AnyType.Is<T>();
 
     public static bool IsAlias<T>(this GirModel.AnyType anyType) where T : GirModel.Type
@@ -66,7 +66,7 @@ public static class AnyTypeExtension
 
     public static bool IsGLibArrayAlias<T>(this GirModel.AnyType anyType) where T : GirModel.Type
         => anyType.TryPickT1(out var arrayType, out _)
-           && arrayType is GirModel.GArrayType
+           && arrayType is GirModel.GLibArrayType
            && arrayType.AnyType.IsAlias<T>();
 }
 

--- a/src/Generation/GirModel/GLib.ArrayType.cs
+++ b/src/Generation/GirModel/GLib.ArrayType.cs
@@ -3,4 +3,4 @@ namespace GirModel;
 /// <summary>
 /// Represents a GLib.Array
 /// </summary>
-public interface GArrayType : ArrayType { }
+public interface GLibArrayType : ArrayType { }

--- a/src/Generation/GirModel/GLib.ByteArrayType.cs
+++ b/src/Generation/GirModel/GLib.ByteArrayType.cs
@@ -3,4 +3,4 @@ namespace GirModel;
 /// <summary>
 /// Represents a GLib.ByteArray
 /// </summary>
-public interface ByteArrayType : ArrayType { }
+public interface GLibByteArrayType : ArrayType { }

--- a/src/Generation/GirModel/GLib.PtrArrayType.cs
+++ b/src/Generation/GirModel/GLib.PtrArrayType.cs
@@ -3,4 +3,4 @@ namespace GirModel;
 /// <summary>
 /// Represents a GLib.PtrArray
 /// </summary>
-public interface PointerArrayType : ArrayType { }
+public interface GLibPtrArrayType : ArrayType { }


### PR DESCRIPTION
The rename matches the original GLib name and makes it more clear that there are special cases for GLib structures in the GirModel.

- [x] I agree that my contribution may be licensed either under MIT or any version of LGPL license.
